### PR TITLE
add vitest ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
         # Set if: always() to also generate the report if tests are failing
         # Only works if you set `reportOnFailure: true` in your vite config as specified above
         if: always()
-        uses:  davelosert/vitest-coverage-report-action@v2
+        uses:  davelosert/vitest-coverage-report-action@v2.8.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
@@ -44,9 +44,36 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
       - name: Run build
         run: pnpm build
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: 'Test'
+        run: pnpm test:coverage
+      - name: 'Report Coverage'
+        # Set if: always() to also generate the report if tests are failing
+        # Only works if you set `reportOnFailure: true` in your vite config as specified above
+        if: always()
+        uses:  davelosert/vitest-coverage-report-action@v2

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import viteFastify from "@fastify/vite/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
@@ -12,5 +13,11 @@ export default defineConfig({
 		port: 3000,
 		strictPort: true,
 		open: true,
+	},
+	test: {
+		coverage: {
+			reporter: ["text", "json-summary", "json"],
+			reportOnFailure: true,
+		},
 	},
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+// the following line is needed to extend the types for vitest
 /// <reference types="vitest/config" />
 import viteFastify from "@fastify/vite/plugin";
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
### やったこと
- vitest ci の追加 https://github.com/marketplace/actions/vitest-coverage-report
- node version を 22 にする

### やってないこと
- `generated` のファイルも coverage に含まれてるのであとで抜く。`generated` のディレクトリはあとで場所が変わる気がするので今は対応しない

### 動作確認
- [ ] ci 通ってる
- [ ] pr に coverage のコメントが追加されている
