### PR TITLE
implement update user front

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ setup.env:
 db.migrate:
 	pnpm prisma migrate dev
 
+.PHONY: db.studio
+db.studio:
+	pnpm prisma studio
+
 .PHONY: run
 run:
 	pnpm run dev

--- a/app/main.ts
+++ b/app/main.ts
@@ -4,7 +4,9 @@ import FastifyVite from "@fastify/vite";
 import { Transaction } from "@infra/database";
 import { PrismaClient } from "@infra/database/generated";
 import { authController } from "@presentation/controllers/auth_controller";
+import { usersController } from "@presentation/controllers/users_controller";
 import { RegisterUserUsecase } from "@usecase/auth/register_user_usecase";
+import { UpdateUserUsecase } from "@usecase/user/update_user_usecase";
 import Fastify from "fastify";
 
 const app = Fastify({ logger: true });
@@ -37,6 +39,8 @@ const start = async () => {
 
 		const registerUserUsecase = new RegisterUserUsecase(tx);
 		await app.register(authController(registerUserUsecase), { prefix: "/api" });
+		const updateUserUsecase = new UpdateUserUsecase(tx);
+		await app.register(usersController(updateUserUsecase), { prefix: "/api" });
 
 		app.get("/*", (_req, reply) => {
 			return reply.html();

--- a/app/presentation/controllers/users_controller.ts
+++ b/app/presentation/controllers/users_controller.ts
@@ -1,0 +1,49 @@
+import { ErrBadRequest } from "@domain/error";
+import {
+	type UpdateUserRequest,
+	updateUserFormSchema,
+} from "@shared/api/users";
+import type { UpdateUserUsecase } from "@usecase/user/update_user_usecase";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import z from "zod";
+
+export const usersController = (updateUserUsecase: UpdateUserUsecase) => {
+	return async (fastify: FastifyInstance) => {
+		fastify.put("/users/me", onUpdateUser(updateUserUsecase));
+	};
+};
+
+const onUpdateUser = (usecase: UpdateUserUsecase) => {
+	return async (
+		req: FastifyRequest<{ Body: UpdateUserRequest }>,
+		reply: FastifyReply,
+	) => {
+		const input = updateUserFormSchema.safeParse({
+			email: req.body.user.email,
+		});
+		if (!input.success) {
+			const flattened = z.flattenError(input.error);
+			throw new ErrBadRequest({
+				userMessage: "入力に誤りがあります",
+				details: {
+					email: flattened.fieldErrors.email?.join(", "),
+				},
+			});
+		}
+		// TODO: セッションからuserIdを取得する
+		// **********************************************************
+		const userId = "01K24DQHXAJ2NFYKPZ812F4HBJ"; // 仮のユーザーID
+		// **********************************************************
+
+		const output = await usecase.execute({
+			id: userId,
+			email: input.data.email,
+		});
+		reply.send({
+			user: {
+				id: output.id,
+				email: output.email,
+			},
+		});
+	};
+};

--- a/client/components/layouts/navigation.ts
+++ b/client/components/layouts/navigation.ts
@@ -23,6 +23,7 @@ export class Navigation extends Component {
               </h1>
               <nav class="space-x-6">
                 ${new Link({ href: "/auth/register", text: "登録" }).render()}
+                ${new Link({ href: "/users/me", text: "変更" }).render()}
               </nav>
             </div>
           </div>

--- a/client/features/users/index.ts
+++ b/client/features/users/index.ts
@@ -1,0 +1,1 @@
+export * from "./update";

--- a/client/features/users/update.ts
+++ b/client/features/users/update.ts
@@ -1,0 +1,70 @@
+import {
+	type UpdateUserRequest,
+	type UpdateUserResponse,
+	updateUserFormSchema,
+} from "@shared/api/users";
+import { ApiClient } from "client/api/api_client";
+import {
+	Button,
+	Component,
+	FloatingBanner,
+	FormInput,
+	SectionTitle,
+} from "client/components";
+import { annotateZodErrors } from "client/components/form/error";
+
+export class UpdateUser extends Component {
+	addEventListeners(): void {
+		const form = document.getElementById("update-user-form");
+		if (form && form instanceof HTMLFormElement) {
+			form.addEventListener("submit", async (e) => {
+				e.preventDefault();
+				const formData = new FormData(form);
+				const rawData = {
+					email: formData.get("email"),
+				};
+
+				const input = updateUserFormSchema.safeParse(rawData);
+				if (!input.success) {
+					annotateZodErrors(input.error);
+					new FloatingBanner({
+						message: "入力に誤りがあります",
+						type: "error",
+					}).show();
+					return;
+				}
+				// TODO: APIエラーのハンドリング
+				await new ApiClient().put<UpdateUserRequest, UpdateUserResponse>(
+					"/api/users/me",
+					{ user: { email: input.data.email } },
+				);
+			});
+		}
+	}
+
+	render(): string {
+		return `
+<div>
+    ${new SectionTitle({ text: "アカウントを編集" }).render()}
+    <div class="max-w-md mx-auto">
+        <form id="update-user-form" novalidate class="space-y-6">
+            ${new FormInput({
+							id: "email",
+							name: "email",
+							type: "email",
+							autocomplete: "email",
+							labelText: "メールアドレス",
+						}).render()}
+            <div class="flex justify-center">
+                ${new Button({
+									width: "full",
+									type: "submit",
+									text: "更新",
+								}).render()}
+            </div>
+        </form>
+    </div>
+</div>
+`;
+	}
+}

--- a/client/router.ts
+++ b/client/router.ts
@@ -2,6 +2,7 @@ import { pathToRegexp } from "path-to-regexp";
 import { Navigation } from "./components";
 import { Register } from "./features/auth";
 import { Home } from "./features/home";
+import { UpdateUser } from "./features/users";
 
 export const router = async () => {
 	// biome-ignore lint/style/noNonNullAssertion: app container は必ず存在する
@@ -14,6 +15,10 @@ export const router = async () => {
 		{
 			path: "/auth/register",
 			component: new Navigation({ child: new Register() }),
+		},
+		{
+			path: "/users/me",
+			component: new Navigation({ child: new UpdateUser() }),
 		},
 	];
 

--- a/shared/api/users.ts
+++ b/shared/api/users.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const updateUserFormSchema = z.object({
+	email: z.email("有効なメールアドレスを入力してください"),
+});
+
+export type UpdateUserRequest = {
+	user: {
+		email: string;
+	};
+};
+
+export type UpdateUserResponse = {
+	user: {
+		id: string;
+		email: string;
+	};
+};


### PR DESCRIPTION
### やったこと

- [ ] ユーザー更新のフロント作成（細かい所はおいておいて、とりあえず真似だけしました）

### やってないこと

- [ ] APIの例外処理
- [ ] 編集画面を開いた時に現在のユーザー情報を取得して表示
- [ ] セッションからID取得

### 動作確認
- [ ] user_controller: 35行目 userIdを既存のidに修正
- [ ] 下記からメールアドレス送信
http://localhost:3000/users/me
- [ ] prisma studioから変更されたことを確認
```
make db.studio
```

### 相談
- [ ] どれを複数形（users）にして、どれが単数のままでいいのか分からなくなってしまいました。コントローラーとフロントまわりだけ複数形にしていますが、命名が間違っていないか確認して頂けると嬉しいです。
