### PR TITLE
57 implement 1v1 pong

### DIFF
--- a/app/domain/model/direct_message.ts
+++ b/app/domain/model/direct_message.ts
@@ -1,29 +1,29 @@
 import { ulid } from "ulid";
-import { User } from './user';
+import type { User } from "./user";
 
 export class DirectMessage {
-  constructor(
-    public readonly id: string,
-    public readonly sender: User,
-    public readonly receiver: User,
-    public readonly content: string,
-    public isRead: boolean,
-    public readonly sentAt: Date,
-  ) {}
+	isRead: boolean;
 
-   public static create(
-    sender: User,
-    receiver: User,
-    content: string,
-   ): DirectMessage {
-     if (sender.id === receiver.id) {
-       throw new Error('Cannot send a message to oneself.');
-     }
-     const id = ulid();
-     return new DirectMessage(id, sender, receiver, content, false, new Date());
-   }
+	constructor(
+		readonly id: string,
+		readonly sender: User,
+		readonly receiver: User,
+		readonly content: string,
+		isRead: boolean,
+		readonly sentAt: Date,
+	) {
+		this.isRead = isRead;
+	}
 
-   public markAsRead(): void {
-       this.isRead = true;
-   }
+	static create(sender: User, receiver: User, content: string): DirectMessage {
+		if (sender.id.equals(receiver.id)) {
+			throw new Error("Cannot send a message to oneself.");
+		}
+		const id = ulid();
+		return new DirectMessage(id, sender, receiver, content, false, new Date());
+	}
+
+	markAsRead(): void {
+		this.isRead = true;
+	}
 }

--- a/app/domain/model/direct_message.ts
+++ b/app/domain/model/direct_message.ts
@@ -1,4 +1,5 @@
 import { ulid } from "ulid";
+import { ErrBadRequest } from "../error";
 import type { User } from "./user";
 
 export class DirectMessage {
@@ -17,7 +18,9 @@ export class DirectMessage {
 
 	static create(sender: User, receiver: User, content: string): DirectMessage {
 		if (sender.id.equals(receiver.id)) {
-			throw new Error("Cannot send a message to oneself.");
+			throw new ErrBadRequest({
+				userMessage: "Cannot send a message to oneself.",
+			});
 		}
 		const id = ulid();
 		return new DirectMessage(id, sender, receiver, content, false, new Date());

--- a/app/domain/model/direct_message.ts
+++ b/app/domain/model/direct_message.ts
@@ -19,7 +19,12 @@ export class DirectMessage {
 	static create(sender: User, receiver: User, content: string): DirectMessage {
 		if (sender.id.equals(receiver.id)) {
 			throw new ErrBadRequest({
-				userMessage: "Cannot send a message to oneself.",
+				userMessage: "自分自身にメッセージを送ることはできません。",
+			});
+		}
+		if (!content?.trim()) {
+			throw new ErrBadRequest({
+				userMessage: "メッセージの内容が空です。",
 			});
 		}
 		const id = ulid();

--- a/app/domain/model/direct_message.ts
+++ b/app/domain/model/direct_message.ts
@@ -1,0 +1,29 @@
+import { ulid } from "ulid";
+import { User } from './user';
+
+export class DirectMessage {
+  constructor(
+    public readonly id: string,
+    public readonly sender: User,
+    public readonly receiver: User,
+    public readonly content: string,
+    public isRead: boolean,
+    public readonly sentAt: Date,
+  ) {}
+
+   public static create(
+    sender: User,
+    receiver: User,
+    content: string,
+   ): DirectMessage {
+     if (sender.id === receiver.id) {
+       throw new Error('Cannot send a message to oneself.');
+     }
+     const id = ulid();
+     return new DirectMessage(id, sender, receiver, content, false, new Date());
+   }
+
+   public markAsRead(): void {
+       this.isRead = true;
+   }
+}

--- a/app/domain/model/friendship.ts
+++ b/app/domain/model/friendship.ts
@@ -1,3 +1,4 @@
+import { ErrBadRequest, ErrForbidden } from "../error";
 import type { User, UserId } from "./user";
 
 export type FriendshipStatus = "pending" | "accepted" | "blocked";
@@ -19,7 +20,9 @@ export class Friendship {
 
 	static create(requester: User, receiver: User): Friendship {
 		if (requester.id.equals(receiver.id)) {
-			throw new Error("Cannot create a friendship with oneself.");
+			throw new ErrBadRequest({
+				userMessage: "Cannot create a friendship with oneself.",
+			});
 		}
 		return new Friendship(
 			requester.id,
@@ -32,7 +35,9 @@ export class Friendship {
 
 	accept(): void {
 		if (this.status !== "pending") {
-			throw new Error("Cannot accept a friendship that is not pending.");
+			throw new ErrForbidden({
+				userMessage: "Cannot accept a friendship that is not pending.",
+			});
 		}
 		this.status = "accepted";
 		this.updatedAt = new Date();

--- a/app/domain/model/friendship.ts
+++ b/app/domain/model/friendship.ts
@@ -5,32 +5,22 @@ export type FriendshipStatus = "pending" | "accepted" | "blocked";
 
 export class Friendship {
 	status: FriendshipStatus;
-	updatedAt: Date;
 
 	constructor(
 		readonly requesterId: UserId,
 		readonly receiverId: UserId,
 		status: FriendshipStatus,
-		readonly createdAt: Date,
-		updatedAt: Date,
 	) {
 		this.status = status;
-		this.updatedAt = updatedAt;
 	}
 
 	static create(requester: User, receiver: User): Friendship {
 		if (requester.id.equals(receiver.id)) {
 			throw new ErrBadRequest({
-				userMessage: "Cannot create a friendship with oneself.",
+				userMessage: "自分自身とフレンドシップを作成することはできません。",
 			});
 		}
-		return new Friendship(
-			requester.id,
-			receiver.id,
-			"pending",
-			new Date(),
-			new Date(),
-		);
+		return new Friendship(requester.id, receiver.id, "pending");
 	}
 
 	accept(): void {
@@ -38,7 +28,23 @@ export class Friendship {
 			throw new ErrForbidden();
 		}
 		this.status = "accepted";
-		this.updatedAt = new Date();
+	}
+
+	block(): void {
+		if (this.status === "blocked") {
+			return;
+		}
+		this.status = "blocked";
+	}
+
+	unblock(): void {
+		if (this.status !== "blocked") {
+			throw new ErrForbidden();
+		}
+	}
+
+	isBlocked(): boolean {
+		return this.status === "blocked";
 	}
 
 	isAccepted(): boolean {

--- a/app/domain/model/friendship.ts
+++ b/app/domain/model/friendship.ts
@@ -1,0 +1,41 @@
+import { User, UserId } from './user';
+
+export type FriendshipStatus = 'pending' | 'accepted' | 'blocked';
+
+export class Friendship {
+  constructor(
+    public readonly requesterId: UserId,
+    public readonly receiverId: UserId,
+    public status: FriendshipStatus,
+    public readonly createdAt: Date,
+    public updatedAt: Date,
+  ) {}
+
+  public static create(
+    requester: User,
+    receiver: User,
+  ): Friendship {
+    if (requester.id === receiver.id) {
+      throw new Error('Cannot create a friendship with oneself.');
+    }
+    return new Friendship(
+      requester.id,
+      receiver.id,
+      'pending',
+      new Date(),
+      new Date(),
+    );
+  }
+
+  public accept(): void {
+    if (this.status !== 'pending') {
+      throw new Error('Cannot accept a friendship that is not pending.');
+    }
+    this.status = 'accepted';
+    this.updatedAt = new Date();
+  }
+  
+  public isAccepted(): boolean {
+      return this.status === 'accepted';
+  }
+}

--- a/app/domain/model/friendship.ts
+++ b/app/domain/model/friendship.ts
@@ -1,41 +1,44 @@
-import { User, UserId } from './user';
+import type { User, UserId } from "./user";
 
-export type FriendshipStatus = 'pending' | 'accepted' | 'blocked';
+export type FriendshipStatus = "pending" | "accepted" | "blocked";
 
 export class Friendship {
-  constructor(
-    public readonly requesterId: UserId,
-    public readonly receiverId: UserId,
-    public status: FriendshipStatus,
-    public readonly createdAt: Date,
-    public updatedAt: Date,
-  ) {}
+	status: FriendshipStatus;
+	updatedAt: Date;
 
-  public static create(
-    requester: User,
-    receiver: User,
-  ): Friendship {
-    if (requester.id === receiver.id) {
-      throw new Error('Cannot create a friendship with oneself.');
-    }
-    return new Friendship(
-      requester.id,
-      receiver.id,
-      'pending',
-      new Date(),
-      new Date(),
-    );
-  }
+	constructor(
+		readonly requesterId: UserId,
+		readonly receiverId: UserId,
+		status: FriendshipStatus,
+		readonly createdAt: Date,
+		updatedAt: Date,
+	) {
+		this.status = status;
+		this.updatedAt = updatedAt;
+	}
 
-  public accept(): void {
-    if (this.status !== 'pending') {
-      throw new Error('Cannot accept a friendship that is not pending.');
-    }
-    this.status = 'accepted';
-    this.updatedAt = new Date();
-  }
-  
-  public isAccepted(): boolean {
-      return this.status === 'accepted';
-  }
+	static create(requester: User, receiver: User): Friendship {
+		if (requester.id.equals(receiver.id)) {
+			throw new Error("Cannot create a friendship with oneself.");
+		}
+		return new Friendship(
+			requester.id,
+			receiver.id,
+			"pending",
+			new Date(),
+			new Date(),
+		);
+	}
+
+	accept(): void {
+		if (this.status !== "pending") {
+			throw new Error("Cannot accept a friendship that is not pending.");
+		}
+		this.status = "accepted";
+		this.updatedAt = new Date();
+	}
+
+	isAccepted(): boolean {
+		return this.status === "accepted";
+	}
 }

--- a/app/domain/model/friendship.ts
+++ b/app/domain/model/friendship.ts
@@ -35,9 +35,7 @@ export class Friendship {
 
 	accept(): void {
 		if (this.status !== "pending") {
-			throw new ErrForbidden({
-				userMessage: "Cannot accept a friendship that is not pending.",
-			});
+			throw new ErrForbidden();
 		}
 		this.status = "accepted";
 		this.updatedAt = new Date();

--- a/app/domain/model/match.ts
+++ b/app/domain/model/match.ts
@@ -1,29 +1,42 @@
 import { ulid } from "ulid";
-import { User } from './user';
+import type { User } from "./user";
 
-export type MatchStatus = 'in_progress' | 'completed';
-export type GameType = 'Pong';
+export type MatchStatus = "in_progress" | "completed";
+export type GameType = "Pong";
 
 export class Match {
-  constructor(
-    public readonly id: string,
-    public readonly participants: User[],
-    public status: MatchStatus,
-    public readonly gameType: GameType,
-    public readonly createdAt: Date,
-    public updatedAt: Date,
-  ) {}
+	status: MatchStatus;
+	updatedAt: Date;
 
-  public static create(participants: User[], gameType: GameType = 'Pong'): Match {
-    if (participants.length < 2) {
-        throw new Error('A match requires at least 2 participants.');
-    }
-    const id = ulid();
-    return new Match(id, participants, 'in_progress', gameType, new Date(), new Date());
-  }
+	constructor(
+		readonly id: string,
+		readonly participants: User[],
+		status: MatchStatus,
+		readonly gameType: GameType,
+		readonly createdAt: Date,
+		updatedAt: Date,
+	) {
+		this.status = status;
+		this.updatedAt = updatedAt;
+	}
 
-  public complete(): void {
-    this.status = 'completed';
-    this.updatedAt = new Date();
-  }
+	static create(participants: User[], gameType: GameType = "Pong"): Match {
+		if (participants.length < 2) {
+			throw new Error("A match requires at least 2 participants.");
+		}
+		const id = ulid();
+		return new Match(
+			id,
+			participants,
+			"in_progress",
+			gameType,
+			new Date(),
+			new Date(),
+		);
+	}
+
+	complete(): void {
+		this.status = "completed";
+		this.updatedAt = new Date();
+	}
 }

--- a/app/domain/model/match.ts
+++ b/app/domain/model/match.ts
@@ -1,0 +1,29 @@
+import { ulid } from "ulid";
+import { User } from './user';
+
+export type MatchStatus = 'in_progress' | 'completed';
+export type GameType = 'Pong';
+
+export class Match {
+  constructor(
+    public readonly id: string,
+    public readonly participants: User[],
+    public status: MatchStatus,
+    public readonly gameType: GameType,
+    public readonly createdAt: Date,
+    public updatedAt: Date,
+  ) {}
+
+  public static create(participants: User[], gameType: GameType = 'Pong'): Match {
+    if (participants.length < 2) {
+        throw new Error('A match requires at least 2 participants.');
+    }
+    const id = ulid();
+    return new Match(id, participants, 'in_progress', gameType, new Date(), new Date());
+  }
+
+  public complete(): void {
+    this.status = 'completed';
+    this.updatedAt = new Date();
+  }
+}

--- a/app/domain/model/match.ts
+++ b/app/domain/model/match.ts
@@ -24,7 +24,7 @@ export class Match {
 	static create(participants: User[], gameType: GameType = "Pong"): Match {
 		if (participants.length < 2) {
 			throw new ErrBadRequest({
-				userMessage: "A match requires at least 2 participants.",
+				userMessage: "試合には少なくとも2人の参加者が必要です。",
 			});
 		}
 		const id = ulid();
@@ -39,6 +39,11 @@ export class Match {
 	}
 
 	complete(): void {
+		if (this.status !== "in_progress") {
+			throw new ErrBadRequest({
+				userMessage: "進行中ではない試合は完了できません。",
+			});
+		}
 		this.status = "completed";
 		this.updatedAt = new Date();
 	}

--- a/app/domain/model/match.ts
+++ b/app/domain/model/match.ts
@@ -1,4 +1,5 @@
 import { ulid } from "ulid";
+import { ErrBadRequest } from "../error";
 import type { User } from "./user";
 
 export type MatchStatus = "in_progress" | "completed";
@@ -22,7 +23,9 @@ export class Match {
 
 	static create(participants: User[], gameType: GameType = "Pong"): Match {
 		if (participants.length < 2) {
-			throw new Error("A match requires at least 2 participants.");
+			throw new ErrBadRequest({
+				userMessage: "A match requires at least 2 participants.",
+			});
 		}
 		const id = ulid();
 		return new Match(

--- a/app/domain/model/match_history.ts
+++ b/app/domain/model/match_history.ts
@@ -1,23 +1,30 @@
 import { ulid } from "ulid";
-import { User } from './user';
+import type { User } from "./user";
 
 export class MatchHistory {
-  constructor(
-    public readonly id: string,
-    public readonly winner: User,
-    public readonly loser: User,
-    public readonly winnerScore: number,
-    public readonly loserScore: number,
-    public readonly playedAt: Date,
-  ) {}
+	constructor(
+		readonly id: string,
+		readonly winner: User,
+		readonly loser: User,
+		readonly winnerScore: number,
+		readonly loserScore: number,
+		readonly playedAt: Date,
+	) {}
 
-   public static create(
-    winner: User,
-    loser: User,
-    winnerScore: number,
-    loserScore: number,
-  ): MatchHistory {
-     const id = ulid();
-     return new MatchHistory(id, winner, loser, winnerScore, loserScore, new Date());
-   }
+	static create(
+		winner: User,
+		loser: User,
+		winnerScore: number,
+		loserScore: number,
+	): MatchHistory {
+		const id = ulid();
+		return new MatchHistory(
+			id,
+			winner,
+			loser,
+			winnerScore,
+			loserScore,
+			new Date(),
+		);
+	}
 }

--- a/app/domain/model/match_history.ts
+++ b/app/domain/model/match_history.ts
@@ -1,0 +1,23 @@
+import { ulid } from "ulid";
+import { User } from './user';
+
+export class MatchHistory {
+  constructor(
+    public readonly id: string,
+    public readonly winner: User,
+    public readonly loser: User,
+    public readonly winnerScore: number,
+    public readonly loserScore: number,
+    public readonly playedAt: Date,
+  ) {}
+
+   public static create(
+    winner: User,
+    loser: User,
+    winnerScore: number,
+    loserScore: number,
+  ): MatchHistory {
+     const id = ulid();
+     return new MatchHistory(id, winner, loser, winnerScore, loserScore, new Date());
+   }
+}

--- a/app/domain/model/match_history.ts
+++ b/app/domain/model/match_history.ts
@@ -1,11 +1,22 @@
 import { ulid } from "ulid";
-import type { User } from "./user";
+import type { User, UserEmail, UserId } from "./user";
+import { ValueObject } from "./value_object";
+
+export class MatchHistoryId extends ValueObject<string, "MatchHistoryId"> {
+	protected validate(value: string): void {
+		if (value.length === 0) {
+			throw new Error("MatchHistoryId cannot be empty");
+		}
+	}
+}
 
 export class MatchHistory {
 	constructor(
-		readonly id: string,
-		readonly winner: User,
-		readonly loser: User,
+		readonly id: MatchHistoryId,
+		readonly winnerId: UserId,
+		readonly loserId: UserId,
+		readonly winnerEmail: UserEmail,
+		readonly loserEmail: UserEmail,
 		readonly winnerScore: number,
 		readonly loserScore: number,
 		readonly playedAt: Date,
@@ -17,11 +28,13 @@ export class MatchHistory {
 		winnerScore: number,
 		loserScore: number,
 	): MatchHistory {
-		const id = ulid();
+		const id = new MatchHistoryId(ulid());
 		return new MatchHistory(
 			id,
-			winner,
-			loser,
+			winner.id,
+			loser.id,
+			winner.email,
+			loser.email,
 			winnerScore,
 			loserScore,
 			new Date(),

--- a/app/domain/repository/direct_message_repository.ts
+++ b/app/domain/repository/direct_message_repository.ts
@@ -1,0 +1,9 @@
+import type { DirectMessage } from "../model/direct_message";
+
+export interface IDirectMessageRepository {
+	save(message: DirectMessage): Promise<DirectMessage>;
+	findMessagesBetweenUsers(
+		userId1: string,
+		userId2: string,
+	): Promise<DirectMessage[]>;
+}

--- a/app/domain/repository/direct_message_repository.ts
+++ b/app/domain/repository/direct_message_repository.ts
@@ -2,6 +2,8 @@ import type { DirectMessage } from "../model/direct_message";
 
 export interface IDirectMessageRepository {
 	save(message: DirectMessage): Promise<DirectMessage>;
+	findById(messageId: string): Promise<DirectMessage | undefined>;
+	update(message: DirectMessage): Promise<DirectMessage>;
 	findMessagesBetweenUsers(
 		userId1: string,
 		userId2: string,

--- a/app/domain/repository/friendship_repository.ts
+++ b/app/domain/repository/friendship_repository.ts
@@ -1,0 +1,10 @@
+import type { Friendship } from "../model/friendship";
+import type { User } from "../model/user";
+
+export interface IFriendshipRepository {
+	save(friendship: Friendship): Promise<Friendship>;
+	findByUserIds(userId1: string, userId2: string): Promise<Friendship | null>;
+	findFriendsByUserId(userId: string): Promise<User[]>;
+	findPendingRequestsByReceiverId(userId: string): Promise<Friendship[]>;
+	delete(friendship: Friendship): Promise<void>;
+}

--- a/app/domain/repository/friendship_repository.ts
+++ b/app/domain/repository/friendship_repository.ts
@@ -3,7 +3,10 @@ import type { User } from "../model/user";
 
 export interface IFriendshipRepository {
 	save(friendship: Friendship): Promise<Friendship>;
-	findByUserIds(userId1: string, userId2: string): Promise<Friendship | null>;
+	findByUserIds(
+		userId1: string,
+		userId2: string,
+	): Promise<Friendship | undefined>;
 	findFriendsByUserId(userId: string): Promise<User[]>;
 	findPendingRequestsByReceiverId(userId: string): Promise<Friendship[]>;
 	delete(friendship: Friendship): Promise<void>;

--- a/app/domain/repository/index.ts
+++ b/app/domain/repository/index.ts
@@ -1,2 +1,4 @@
+export * from "./direct_message_repository";
+export * from "./friendship_repository";
 export * from "./repository";
 export * from "./user_repository";

--- a/app/domain/repository/match_history_repository.ts
+++ b/app/domain/repository/match_history_repository.ts
@@ -1,0 +1,6 @@
+import type { MatchHistory } from "../model/match_history";
+
+export interface IMatchHistoryRepository {
+	save(matchHistory: MatchHistory): Promise<MatchHistory>;
+	findByUserId(userId: string): Promise<MatchHistory[]>;
+}

--- a/app/domain/repository/match_repository.ts
+++ b/app/domain/repository/match_repository.ts
@@ -1,0 +1,7 @@
+import type { Match } from "../model/match";
+
+export interface IMatchRepository {
+	save(match: Match): Promise<Match>;
+	findById(id: string): Promise<Match | null>;
+	findInProgressMatchByUserId(userId: string): Promise<Match | null>;
+}

--- a/app/domain/repository/matchmaking_queue_repository.ts
+++ b/app/domain/repository/matchmaking_queue_repository.ts
@@ -1,0 +1,7 @@
+import type { User } from "../model/user";
+
+export interface IMatchmakingQueueRepository {
+	add(user: User): Promise<void>;
+	remove(userId: string): Promise<void>;
+	pop(): Promise<[User, User] | undefined>;
+}

--- a/app/domain/repository/repository.ts
+++ b/app/domain/repository/repository.ts
@@ -1,5 +1,9 @@
+import type { IDirectMessageRepository } from "./direct_message_repository";
+import type { IFriendshipRepository } from "./friendship_repository";
 import type { IUserRepository } from "./user_repository";
 
 export interface IRepository {
 	newUserRepository(): IUserRepository;
+	newFriendshipRepository(): IFriendshipRepository;
+	newDirectMessageRepository(): IDirectMessageRepository;
 }

--- a/app/domain/service/matchmaking_service.ts
+++ b/app/domain/service/matchmaking_service.ts
@@ -1,4 +1,5 @@
 import type { ITransaction } from "../../usecase/transaction";
+import { ErrBadRequest } from "../error";
 import { Match } from "../model/match";
 import type { User } from "../model/user";
 import type { IMatchRepository } from "../repository/match_repository";
@@ -21,7 +22,7 @@ export class MatchmakingService {
 		const existingMatch =
 			await this.matchRepository.findInProgressMatchByUserId(user.id.value);
 		if (existingMatch) {
-			throw new Error("User is already in a match.");
+			throw new ErrBadRequest({ userMessage: "User is already in a match." });
 		}
 
 		await this.matchmakingQueue.add(user);

--- a/app/domain/service/matchmaking_service.ts
+++ b/app/domain/service/matchmaking_service.ts
@@ -3,47 +3,50 @@ import { ErrBadRequest } from "../error";
 import { Match } from "../model/match";
 import type { User } from "../model/user";
 import type { IMatchRepository } from "../repository/match_repository";
-
-export interface IMatchmakingQueue {
-	add(user: User): Promise<void>;
-	remove(userId: string): Promise<void>;
-	findMatch(): Promise<[User, User] | null>;
-}
+import type { IMatchmakingQueueRepository } from "../repository/matchmaking_queue_repository";
 
 export class MatchmakingService {
 	constructor(
 		private readonly transaction: ITransaction,
 		private readonly matchRepository: IMatchRepository,
-		private readonly matchmakingQueue: IMatchmakingQueue,
+		private readonly matchmakingQueueRepository: IMatchmakingQueueRepository,
 	) {}
 
-	async join(user: User): Promise<Match | null> {
+	async join(user: User): Promise<Match | undefined> {
 		// 既に進行中の試合がないか確認
 		const existingMatch =
 			await this.matchRepository.findInProgressMatchByUserId(user.id.value);
 		if (existingMatch) {
-			throw new ErrBadRequest({ userMessage: "User is already in a match." });
+			throw new ErrBadRequest({
+				userMessage: "ユーザーは既に試合に参加しています。",
+			});
 		}
 
-		await this.matchmakingQueue.add(user);
-		const matchedUsers = await this.matchmakingQueue.findMatch();
+		await this.matchmakingQueueRepository.add(user);
+		const matchedUsers = await this.matchmakingQueueRepository.pop();
 
 		if (matchedUsers) {
-			const newMatch: Match | null = await this.transaction.exec(async () => {
-				const match = Match.create(matchedUsers);
-				const savedMatch = await this.matchRepository.save(match);
-				// キューからマッチしたユーザーを削除
-				await this.matchmakingQueue.remove(matchedUsers[0].id.value);
-				await this.matchmakingQueue.remove(matchedUsers[1].id.value);
-				return savedMatch;
-			});
+			const newMatch: Match | undefined = await this.transaction.exec(
+				async () => {
+					const match = Match.create(matchedUsers);
+					const savedMatch = await this.matchRepository.save(match);
+					// キューからマッチしたユーザーを削除
+					await this.matchmakingQueueRepository.remove(
+						matchedUsers[0].id.value,
+					);
+					await this.matchmakingQueueRepository.remove(
+						matchedUsers[1].id.value,
+					);
+					return savedMatch;
+				},
+			);
 			// WebSocketなどでマッチング成功を通知する
 			return newMatch;
 		}
-		return null;
+		return undefined;
 	}
 
 	async leave(userId: string): Promise<void> {
-		await this.matchmakingQueue.remove(userId);
+		await this.matchmakingQueueRepository.remove(userId);
 	}
 }

--- a/app/domain/service/matchmaking_service.ts
+++ b/app/domain/service/matchmaking_service.ts
@@ -29,13 +29,13 @@ export class MatchmakingService {
 		const matchedUsers = await this.matchmakingQueue.findMatch();
 
 		if (matchedUsers) {
-			let newMatch: Match | null = null;
-			await this.transaction.exec(async () => {
+			const newMatch: Match | null = await this.transaction.exec(async () => {
 				const match = Match.create(matchedUsers);
-				newMatch = await this.matchRepository.save(match);
+				const savedMatch = await this.matchRepository.save(match);
 				// キューからマッチしたユーザーを削除
 				await this.matchmakingQueue.remove(matchedUsers[0].id.value);
 				await this.matchmakingQueue.remove(matchedUsers[1].id.value);
+				return savedMatch;
 			});
 			// WebSocketなどでマッチング成功を通知する
 			return newMatch;

--- a/app/domain/service/matchmaking_service.ts
+++ b/app/domain/service/matchmaking_service.ts
@@ -1,0 +1,48 @@
+import type { ITransaction } from "../../usecase/transaction";
+import { Match } from "../model/match";
+import type { User } from "../model/user";
+import type { IMatchRepository } from "../repository/match_repository";
+
+export interface IMatchmakingQueue {
+	add(user: User): Promise<void>;
+	remove(userId: string): Promise<void>;
+	findMatch(): Promise<[User, User] | null>;
+}
+
+export class MatchmakingService {
+	constructor(
+		private readonly transaction: ITransaction,
+		private readonly matchRepository: IMatchRepository,
+		private readonly matchmakingQueue: IMatchmakingQueue,
+	) {}
+
+	async join(user: User): Promise<Match | null> {
+		// 既に進行中の試合がないか確認
+		const existingMatch =
+			await this.matchRepository.findInProgressMatchByUserId(user.id.value);
+		if (existingMatch) {
+			throw new Error("User is already in a match.");
+		}
+
+		await this.matchmakingQueue.add(user);
+		const matchedUsers = await this.matchmakingQueue.findMatch();
+
+		if (matchedUsers) {
+			let newMatch: Match | null = null;
+			await this.transaction.exec(async () => {
+				const match = Match.create(matchedUsers);
+				newMatch = await this.matchRepository.save(match);
+				// キューからマッチしたユーザーを削除
+				await this.matchmakingQueue.remove(matchedUsers[0].id.value);
+				await this.matchmakingQueue.remove(matchedUsers[1].id.value);
+			});
+			// WebSocketなどでマッチング成功を通知する
+			return newMatch;
+		}
+		return null;
+	}
+
+	async leave(userId: string): Promise<void> {
+		await this.matchmakingQueue.remove(userId);
+	}
+}

--- a/app/infra/database/direct_message_repository.ts
+++ b/app/infra/database/direct_message_repository.ts
@@ -1,0 +1,85 @@
+import { DirectMessage } from "@domain/model/direct_message";
+import { User, UserEmail, UserId } from "@domain/model/user";
+import type { IDirectMessageRepository } from "@domain/repository/direct_message_repository";
+import type { Client } from "./repository";
+
+// PrismaのUserモデルからドメインのUserモデルへ変換
+const toUserDomain = (prismaUser: {
+	id: string;
+	email: string | null;
+}): User => {
+	if (!prismaUser.email) {
+		throw new Error(`User with id ${prismaUser.id} has no email.`);
+	}
+	return User.reconstruct(
+		new UserId(prismaUser.id),
+		new UserEmail(prismaUser.email),
+	);
+};
+
+// PrismaのDirectMessageモデルからドメインのDirectMessageモデルへ変換
+const toDirectMessageDomain = (prismaMessage: {
+	id: string;
+	content: string;
+	isRead: boolean;
+	sentAt: Date;
+	sender: { id: string; email: string | null };
+	receiver: { id: string; email: string | null };
+}): DirectMessage => {
+	const sender = toUserDomain(prismaMessage.sender);
+	const receiver = toUserDomain(prismaMessage.receiver);
+
+	return new DirectMessage(
+		prismaMessage.id,
+		sender,
+		receiver,
+		prismaMessage.content,
+		prismaMessage.isRead,
+		prismaMessage.sentAt,
+	);
+};
+
+export class DirectMessageRepository implements IDirectMessageRepository {
+	constructor(private readonly client: Client) {}
+
+	async save(message: DirectMessage): Promise<DirectMessage> {
+		const saved = await this.client.directMessage.create({
+			data: {
+				id: message.id,
+				senderId: message.sender.id.value,
+				receiverId: message.receiver.id.value,
+				content: message.content,
+				isRead: message.isRead,
+				sentAt: message.sentAt,
+			},
+			include: {
+				sender: true,
+				receiver: true,
+			},
+		});
+		return toDirectMessageDomain(saved);
+	}
+
+	async findMessagesBetweenUsers(
+		userId1: string,
+		userId2: string,
+	): Promise<DirectMessage[]> {
+		const messages = await this.client.directMessage.findMany({
+			where: {
+				OR: [
+					{ senderId: userId1, receiverId: userId2 },
+					{ senderId: userId2, receiverId: userId1 },
+				],
+			},
+			include: {
+				sender: true,
+				receiver: true,
+			},
+			orderBy: {
+				sentAt: "asc",
+			},
+		});
+
+		return messages.map(toDirectMessageDomain);
+	}
+}

--- a/app/infra/database/friendship_repository.ts
+++ b/app/infra/database/friendship_repository.ts
@@ -104,7 +104,7 @@ export class FriendshipRepository implements IFriendshipRepository {
 		return pending.map(toFriendshipDomain);
 	}
 
-    async delete(friendship: Friendship): Promise<void> {
+	async delete(friendship: Friendship): Promise<void> {
 		await this.client.friendship.delete({
 			where: {
 				requesterId_receiverId: {

--- a/app/infra/database/friendship_repository.ts
+++ b/app/infra/database/friendship_repository.ts
@@ -104,19 +104,13 @@ export class FriendshipRepository implements IFriendshipRepository {
 		return pending.map(toFriendshipDomain);
 	}
 
-	async delete(friendship: Friendship): Promise<void> {
-		await this.client.friendship.deleteMany({
+    async delete(friendship: Friendship): Promise<void> {
+		await this.client.friendship.delete({
 			where: {
-				OR: [
-					{
-						requesterId: friendship.requesterId.value,
-						receiverId: friendship.receiverId.value,
-					},
-					{
-						requesterId: friendship.receiverId.value,
-						receiverId: friendship.requesterId.value,
-					},
-				],
+				requesterId_receiverId: {
+					requesterId: friendship.requesterId.value,
+					receiverId: friendship.receiverId.value,
+				},
 			},
 		});
 	}

--- a/app/infra/database/friendship_repository.ts
+++ b/app/infra/database/friendship_repository.ts
@@ -1,0 +1,123 @@
+import { Friendship } from "@domain/model/friendship";
+import { User, UserEmail, UserId } from "@domain/model/user";
+import type { IFriendshipRepository } from "@domain/repository/friendship_repository";
+import type { Client } from "./repository";
+
+// PrismaのUserモデルからドメインのUserモデルへ変換
+const toUserDomain = (prismaUser: {
+	id: string;
+	email: string | null;
+}): User => {
+	// emailがnullの場合はエラーとするか、デフォルト値を設定するかは要件次第
+	if (!prismaUser.email) {
+		throw new Error(`User with id ${prismaUser.id} has no email.`);
+	}
+	return User.reconstruct(
+		new UserId(prismaUser.id),
+		new UserEmail(prismaUser.email),
+	);
+};
+
+// PrismaのFriendshipモデルからドメインのFriendshipモデルへ変換
+const toFriendshipDomain = (prismaFriendship: {
+	requesterId: string;
+	receiverId: string;
+	status: string;
+	createdAt: Date;
+	updatedAt: Date;
+}): Friendship => {
+	// PrismaのFriendshipStatus型はstringとして扱われるためキャスト
+	const status = prismaFriendship.status as "pending" | "accepted" | "blocked";
+	return new Friendship(
+		new UserId(prismaFriendship.requesterId),
+		new UserId(prismaFriendship.receiverId),
+		status,
+		prismaFriendship.createdAt,
+		prismaFriendship.updatedAt,
+	);
+};
+
+export class FriendshipRepository implements IFriendshipRepository {
+	constructor(private readonly client: Client) {}
+
+	async save(friendship: Friendship): Promise<Friendship> {
+		const saved = await this.client.friendship.upsert({
+			where: {
+				requesterId_receiverId: {
+					requesterId: friendship.requesterId.value,
+					receiverId: friendship.receiverId.value,
+				},
+			},
+			update: {
+				status: friendship.status,
+			},
+			create: {
+				requesterId: friendship.requesterId.value,
+				receiverId: friendship.receiverId.value,
+				status: friendship.status,
+			},
+		});
+		return toFriendshipDomain(saved);
+	}
+
+	async findByUserIds(
+		userId1: string,
+		userId2: string,
+	): Promise<Friendship | null> {
+		const friendship = await this.client.friendship.findFirst({
+			where: {
+				OR: [
+					{ requesterId: userId1, receiverId: userId2 },
+					{ requesterId: userId2, receiverId: userId1 },
+				],
+			},
+		});
+		return friendship ? toFriendshipDomain(friendship) : null;
+	}
+
+	async findFriendsByUserId(userId: string): Promise<User[]> {
+		const friendships = await this.client.friendship.findMany({
+			where: {
+				status: "accepted",
+				OR: [{ requesterId: userId }, { receiverId: userId }],
+			},
+			include: {
+				requester: true,
+				receiver: true,
+			},
+		});
+
+		return friendships.map((f) =>
+			f.requesterId === userId
+				? toUserDomain(f.receiver)
+				: toUserDomain(f.requester),
+		);
+	}
+
+	async findPendingRequestsByReceiverId(userId: string): Promise<Friendship[]> {
+		const pending = await this.client.friendship.findMany({
+			where: {
+				receiverId: userId,
+				status: "pending",
+			},
+		});
+		return pending.map(toFriendshipDomain);
+	}
+
+	async delete(friendship: Friendship): Promise<void> {
+		await this.client.friendship.deleteMany({
+			where: {
+				OR: [
+					{
+						requesterId: friendship.requesterId.value,
+						receiverId: friendship.receiverId.value,
+					},
+					{
+						requesterId: friendship.receiverId.value,
+						receiverId: friendship.requesterId.value,
+					},
+				],
+			},
+		});
+	}
+}

--- a/app/infra/database/repository.ts
+++ b/app/infra/database/repository.ts
@@ -1,4 +1,9 @@
-import type { IRepository, IUserRepository } from "@domain/repository";
+import type { IDirectMessageRepository } from "@domain/repository/direct_message_repository";
+import type { IFriendshipRepository } from "@domain/repository/friendship_repository";
+import type { IRepository } from "@domain/repository/repository";
+import type { IUserRepository } from "@domain/repository/user_repository";
+import { DirectMessageRepository } from "./direct_message_repository";
+import { FriendshipRepository } from "./friendship_repository";
 import type { Prisma, PrismaClient } from "./generated";
 import { UserRepository } from "./user_repository";
 
@@ -9,5 +14,13 @@ export class Repository implements IRepository {
 
 	newUserRepository(): IUserRepository {
 		return new UserRepository(this.client);
+	}
+
+	newFriendshipRepository(): IFriendshipRepository {
+		return new FriendshipRepository(this.client);
+	}
+
+	newDirectMessageRepository(): IDirectMessageRepository {
+		return new DirectMessageRepository(this.client);
 	}
 }

--- a/app/usecase/auth/register_user_usecase.spec.ts
+++ b/app/usecase/auth/register_user_usecase.spec.ts
@@ -1,6 +1,11 @@
+// ==> app/usecase/auth/register_user_usecase.spec.ts <==
 import { ErrBadRequest } from "@domain/error";
 import { User, UserEmail } from "@domain/model";
-import type { IUserRepository } from "@domain/repository";
+import type {
+	IDirectMessageRepository,
+	IFriendshipRepository,
+	IUserRepository,
+} from "@domain/repository";
 import type { ITransaction } from "@usecase/transaction";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -20,6 +25,8 @@ describe("RegisterUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});
@@ -39,6 +46,8 @@ describe("RegisterUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, NotFoundError } from "@domain/error";
+import { ErrBadRequest, ErrNotFound } from "@domain/error";
 import { DirectMessage } from "@domain/model/direct_message";
 import { User, UserEmail } from "@domain/model/user";
 import type { IDirectMessageRepository } from "@domain/repository/direct_message_repository";
@@ -54,25 +54,25 @@ describe("SendDirectMessageUsecase", () => {
 		expect(message.sender.id.equals(sender.id)).toBe(true);
 	});
 
-	it("should throw BadRequestError when sending to oneself", async () => {
+	it("should throw ErrBadRequest when sending to oneself", async () => {
 		const input = {
 			senderId: sender.id.value,
 			receiverId: sender.id.value,
 			content: "Hello me!",
 		};
-		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
+		await expect(usecase.execute(input)).rejects.toThrow(ErrBadRequest);
 	});
 
-	it("should throw BadRequestError for empty content", async () => {
+	it("should throw ErrBadRequest for empty content", async () => {
 		const input = {
 			senderId: sender.id.value,
 			receiverId: receiver.id.value,
 			content: "  ",
 		};
-		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
+		await expect(usecase.execute(input)).rejects.toThrow(ErrBadRequest);
 	});
 
-	it("should throw NotFoundError if sender does not exist", async () => {
+	it("should throw ErrNotFound if sender does not exist", async () => {
 		userRepo.findById
 			.mockResolvedValueOnce(undefined)
 			.mockResolvedValueOnce(receiver);
@@ -81,7 +81,7 @@ describe("SendDirectMessageUsecase", () => {
 			receiverId: receiver.id.value,
 			content: "Hello!",
 		};
-		await expect(usecase.execute(input)).rejects.toThrow(NotFoundError);
+		await expect(usecase.execute(input)).rejects.toThrow(ErrNotFound);
 	});
 });
 

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -1,0 +1,122 @@
+import { BadRequestError, NotFoundError } from "@domain/error";
+import { DirectMessage } from "@domain/model/direct_message";
+import { User, UserEmail } from "@domain/model/user";
+import type { IDirectMessageRepository } from "@domain/repository/direct_message_repository";
+import type { IFriendshipRepository } from "@domain/repository/friendship_repository";
+import type { IUserRepository } from "@domain/repository/user_repository";
+import type { ITransaction } from "@usecase/transaction";
+import { ulid } from "ulid";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { GetDirectMessagesUsecase } from "./get_direct_messages_usecase";
+import { SendDirectMessageUsecase } from "./send_direct_message_usecase";
+
+// --- Common Mocks ---
+const userRepo = mock<IUserRepository>();
+const messageRepo = mock<IDirectMessageRepository>();
+const friendshipRepo = mock<IFriendshipRepository>();
+const tx = mock<ITransaction>();
+
+const mockRepos = {
+	newUserRepository: () => userRepo,
+	newDirectMessageRepository: () => messageRepo,
+	newFriendshipRepository: () => friendshipRepo,
+};
+tx.exec.mockImplementation(async (callback) => callback(mockRepos));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+// --- Test Suites ---
+
+describe("SendDirectMessageUsecase", () => {
+	const usecase = new SendDirectMessageUsecase(tx);
+	const sender = User.create(new UserEmail("sender@test.com"));
+	const receiver = User.create(new UserEmail("receiver@test.com"));
+
+	it("should send a message successfully", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(sender)
+			.mockResolvedValueOnce(receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(null);
+		messageRepo.save.mockImplementation(async (msg) => msg);
+
+		const input = {
+			senderId: sender.id.value,
+			receiverId: receiver.id.value,
+			content: "Hello!",
+		};
+		const message = await usecase.execute(input);
+
+		expect(messageRepo.save).toHaveBeenCalledOnce();
+		expect(message.content).toBe(input.content);
+		expect(message.sender.id.equals(sender.id)).toBe(true);
+	});
+
+	it("should throw BadRequestError when sending to oneself", async () => {
+		const input = {
+			senderId: sender.id.value,
+			receiverId: sender.id.value,
+			content: "Hello me!",
+		};
+		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError for empty content", async () => {
+		const input = {
+			senderId: sender.id.value,
+			receiverId: receiver.id.value,
+			content: "  ",
+		};
+		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw NotFoundError if sender does not exist", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(receiver);
+		const input = {
+			senderId: ulid(),
+			receiverId: receiver.id.value,
+			content: "Hello!",
+		};
+		await expect(usecase.execute(input)).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe("GetDirectMessagesUsecase", () => {
+	const usecase = new GetDirectMessagesUsecase(tx);
+	const user1 = User.create(new UserEmail("user1@test.com"));
+	const user2 = User.create(new UserEmail("user2@test.com"));
+
+	it("should return a list of messages between two users", async () => {
+		const messages = [
+			DirectMessage.create(user1, user2, "Hi"),
+			DirectMessage.create(user2, user1, "Hello back"),
+		];
+		messageRepo.findMessagesBetweenUsers.mockResolvedValue(messages);
+
+		const result = await usecase.execute({
+			userId: user1.id.value,
+			correspondentId: user2.id.value,
+		});
+
+		expect(result).toHaveLength(2);
+		expect(messageRepo.findMessagesBetweenUsers).toHaveBeenCalledWith(
+			user1.id.value,
+			user2.id.value,
+		);
+	});
+
+	it("should return an empty array if there are no messages", async () => {
+		messageRepo.findMessagesBetweenUsers.mockResolvedValue([]);
+
+		const result = await usecase.execute({
+			userId: user1.id.value,
+			correspondentId: user2.id.value,
+		});
+
+		expect(result).toHaveLength(0);
+	});
+});

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -56,6 +56,7 @@ describe("SendDirectMessageUsecase", () => {
 	});
 
 	it("should throw ErrBadRequest when sending to oneself", async () => {
+		userRepo.findById.mockResolvedValue(sender);
 		const input = {
 			senderId: sender.id.value,
 			receiverId: sender.id.value,
@@ -65,6 +66,9 @@ describe("SendDirectMessageUsecase", () => {
 	});
 
 	it("should throw ErrBadRequest for empty content", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(sender)
+			.mockResolvedValueOnce(receiver);
 		const input = {
 			senderId: sender.id.value,
 			receiverId: receiver.id.value,

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -152,8 +152,8 @@ describe("GetDirectMessagesUsecase", () => {
 		messageRepo.findMessagesBetweenUsers.mockResolvedValue(messages);
 
 		const result = await usecase.execute({
-			userId: user1.id.value,
-			correspondentId: user2.id.value,
+			senderId: user1.id.value,
+			receiverId: user2.id.value,
 		});
 
 		expect(result).toHaveLength(2);
@@ -168,33 +168,33 @@ describe("GetDirectMessagesUsecase", () => {
 		messageRepo.findMessagesBetweenUsers.mockResolvedValue([]);
 
 		const result = await usecase.execute({
-			userId: user1.id.value,
-			correspondentId: user2.id.value,
+			senderId: user1.id.value,
+			receiverId: user2.id.value,
 		});
 
 		expect(result).toHaveLength(0);
 	});
 
-	it("should throw ErrNotFound if userId does not exist", async () => {
+	it("should throw ErrNotFound if senderId does not exist", async () => {
 		userRepo.findById
 			.mockResolvedValueOnce(undefined)
 			.mockResolvedValueOnce(user2);
 		await expect(
 			usecase.execute({
-				userId: ulid(),
-				correspondentId: user2.id.value,
+				senderId: ulid(),
+				receiverId: user2.id.value,
 			}),
 		).rejects.toThrow(ErrNotFound);
 	});
 
-	it("should throw ErrNotFound if correspondentId does not exist", async () => {
+	it("should throw ErrNotFound if receiverId does not exist", async () => {
 		userRepo.findById
 			.mockResolvedValueOnce(user1)
 			.mockResolvedValueOnce(undefined);
 		await expect(
 			usecase.execute({
-				userId: user1.id.value,
-				correspondentId: ulid(),
+				senderId: user1.id.value,
+				receiverId: ulid(),
 			}),
 		).rejects.toThrow(ErrNotFound);
 	});

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -140,9 +140,7 @@ describe("GetDirectMessagesUsecase", () => {
 	});
 
 	it("should return a list of messages between two users", async () => {
-		userRepo.findById
-			.mockResolvedValueOnce(user1)
-			.mockResolvedValueOnce(user2);
+		userRepo.findById.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2);
 		const messages = [
 			DirectMessage.create(user1, user2, "Hi"),
 			DirectMessage.create(user2, user1, "Hello back"),
@@ -162,9 +160,7 @@ describe("GetDirectMessagesUsecase", () => {
 	});
 
 	it("should return an empty array if there are no messages", async () => {
-		userRepo.findById
-			.mockResolvedValueOnce(user1)
-			.mockResolvedValueOnce(user2);
+		userRepo.findById.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2);
 		messageRepo.findMessagesBetweenUsers.mockResolvedValue([]);
 
 		const result = await usecase.execute({

--- a/app/usecase/chat/direct_message_usecase.spec.ts
+++ b/app/usecase/chat/direct_message_usecase.spec.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 import { ErrBadRequest, ErrNotFound } from "@domain/error";
-=======
-import { BadRequestError, NotFoundError } from "@domain/error";
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 import { DirectMessage } from "@domain/model/direct_message";
 import { User, UserEmail } from "@domain/model/user";
 import type { IDirectMessageRepository } from "@domain/repository/direct_message_repository";
@@ -58,43 +54,25 @@ describe("SendDirectMessageUsecase", () => {
 		expect(message.sender.id.equals(sender.id)).toBe(true);
 	});
 
-<<<<<<< HEAD
 	it("should throw ErrBadRequest when sending to oneself", async () => {
-=======
-	it("should throw BadRequestError when sending to oneself", async () => {
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 		const input = {
 			senderId: sender.id.value,
 			receiverId: sender.id.value,
 			content: "Hello me!",
 		};
-<<<<<<< HEAD
 		await expect(usecase.execute(input)).rejects.toThrow(ErrBadRequest);
 	});
 
 	it("should throw ErrBadRequest for empty content", async () => {
-=======
-		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
-	});
-
-	it("should throw BadRequestError for empty content", async () => {
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 		const input = {
 			senderId: sender.id.value,
 			receiverId: receiver.id.value,
 			content: "  ",
 		};
-<<<<<<< HEAD
 		await expect(usecase.execute(input)).rejects.toThrow(ErrBadRequest);
 	});
 
 	it("should throw ErrNotFound if sender does not exist", async () => {
-=======
-		await expect(usecase.execute(input)).rejects.toThrow(BadRequestError);
-	});
-
-	it("should throw NotFoundError if sender does not exist", async () => {
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 		userRepo.findById
 			.mockResolvedValueOnce(undefined)
 			.mockResolvedValueOnce(receiver);
@@ -103,11 +81,7 @@ describe("SendDirectMessageUsecase", () => {
 			receiverId: receiver.id.value,
 			content: "Hello!",
 		};
-<<<<<<< HEAD
 		await expect(usecase.execute(input)).rejects.toThrow(ErrNotFound);
-=======
-		await expect(usecase.execute(input)).rejects.toThrow(NotFoundError);
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 	});
 });
 

--- a/app/usecase/chat/get_direct_messages_usecase.ts
+++ b/app/usecase/chat/get_direct_messages_usecase.ts
@@ -1,0 +1,25 @@
+import type { DirectMessage } from "@domain/model/direct_message";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface IGetDirectMessagesUsecase {
+	userId: string;
+	correspondentId: string;
+}
+
+export class GetDirectMessagesUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: IGetDirectMessagesUsecase): Promise<DirectMessage[]> {
+		const userId = new UserId(input.userId);
+		const correspondentId = new UserId(input.correspondentId);
+
+		return this.transaction.exec(async (repo) => {
+			const messageRepository = repo.newDirectMessageRepository();
+			return messageRepository.findMessagesBetweenUsers(
+				userId.value,
+				correspondentId.value,
+			);
+		});
+	}
+}

--- a/app/usecase/chat/get_direct_messages_usecase.ts
+++ b/app/usecase/chat/get_direct_messages_usecase.ts
@@ -1,3 +1,4 @@
+import { ErrNotFound } from "@domain/error";
 import type { DirectMessage } from "@domain/model/direct_message";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -15,6 +16,16 @@ export class GetDirectMessagesUsecase {
 		const correspondentId = new UserId(input.correspondentId);
 
 		return this.transaction.exec(async (repo) => {
+			const userRepository = repo.newUserRepository();
+			const user = await userRepository.findById(userId);
+			if (!user) {
+				throw new ErrNotFound();
+			}
+			const correspondent = await userRepository.findById(correspondentId);
+			if (!correspondent) {
+				throw new ErrNotFound();
+			}
+
 			const messageRepository = repo.newDirectMessageRepository();
 			return messageRepository.findMessagesBetweenUsers(
 				userId.value,

--- a/app/usecase/chat/get_direct_messages_usecase.ts
+++ b/app/usecase/chat/get_direct_messages_usecase.ts
@@ -3,10 +3,10 @@ import type { DirectMessage } from "@domain/model/direct_message";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface IGetDirectMessagesUsecase {
+type IGetDirectMessagesUsecase = {
 	userId: string;
 	correspondentId: string;
-}
+};
 
 export class GetDirectMessagesUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/chat/get_direct_messages_usecase.ts
+++ b/app/usecase/chat/get_direct_messages_usecase.ts
@@ -4,16 +4,16 @@ import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
 type IGetDirectMessagesUsecase = {
-	userId: string;
-	correspondentId: string;
+	senderId: string;
+	receiverId: string;
 };
 
 export class GetDirectMessagesUsecase {
 	constructor(private readonly transaction: ITransaction) {}
 
 	async execute(input: IGetDirectMessagesUsecase): Promise<DirectMessage[]> {
-		const userId = new UserId(input.userId);
-		const correspondentId = new UserId(input.correspondentId);
+		const userId = new UserId(input.senderId);
+		const correspondentId = new UserId(input.receiverId);
 
 		return this.transaction.exec(async (repo) => {
 			const userRepository = repo.newUserRepository();

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 import { ErrBadRequest, ErrForbidden, ErrNotFound } from "@domain/error";
-=======
-import { BadRequestError, ForbiddenError, NotFoundError } from "@domain/error";
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 import { DirectMessage } from "@domain/model/direct_message";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -21,21 +17,13 @@ export class SendDirectMessageUsecase {
 		const receiverId = new UserId(input.receiverId);
 
 		if (senderId.equals(receiverId)) {
-<<<<<<< HEAD
 			throw new ErrBadRequest({
-=======
-			throw new BadRequestError({
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 				userMessage: "Cannot send a message to oneself.",
 			});
 		}
 
 		if (!input.content?.trim()) {
-<<<<<<< HEAD
 			throw new ErrBadRequest({
-=======
-			throw new BadRequestError({
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 				userMessage: "Message content cannot be empty.",
 			});
 		}
@@ -50,11 +38,7 @@ export class SendDirectMessageUsecase {
 			]);
 
 			if (!sender || !receiver) {
-<<<<<<< HEAD
 				throw new ErrNotFound();
-=======
-				throw new NotFoundError();
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 			}
 
 			const friendshipRepo = repo.newFriendshipRepository();
@@ -63,11 +47,7 @@ export class SendDirectMessageUsecase {
 				receiverId.value,
 			);
 			if (block?.status === "blocked") {
-<<<<<<< HEAD
 				throw new ErrForbidden();
-=======
-				throw new ForbiddenError();
->>>>>>> 81e95bd62da8aa82a9fc1f55cc9c1fe4f9c38f2a
 			}
 
 			const message = DirectMessage.create(sender, receiver, input.content);

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -1,0 +1,57 @@
+import { BadRequestError, ForbiddenError, NotFoundError } from "@domain/error";
+import { DirectMessage } from "@domain/model/direct_message";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface ISendDirectMessageUsecase {
+	senderId: string;
+	receiverId: string;
+	content: string;
+}
+
+export class SendDirectMessageUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: ISendDirectMessageUsecase): Promise<DirectMessage> {
+		const senderId = new UserId(input.senderId);
+		const receiverId = new UserId(input.receiverId);
+
+		if (senderId.equals(receiverId)) {
+			throw new BadRequestError({
+				userMessage: "Cannot send a message to oneself.",
+			});
+		}
+
+		if (!input.content?.trim()) {
+			throw new BadRequestError({
+				userMessage: "Message content cannot be empty.",
+			});
+		}
+
+		return this.transaction.exec(async (repo) => {
+			const userRepository = repo.newUserRepository();
+			const messageRepository = repo.newDirectMessageRepository();
+
+			const [sender, receiver] = await Promise.all([
+				userRepository.findById(senderId),
+				userRepository.findById(receiverId),
+			]);
+
+			if (!sender || !receiver) {
+				throw new NotFoundError();
+			}
+
+			const friendshipRepo = repo.newFriendshipRepository();
+			const block = await friendshipRepo.findByUserIds(
+				senderId.value,
+				receiverId.value,
+			);
+			if (block?.status === "blocked") {
+				throw new ForbiddenError();
+			}
+
+			const message = DirectMessage.create(sender, receiver, input.content);
+			return messageRepository.save(message);
+		});
+	}
+}

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -34,7 +34,7 @@ export class SendDirectMessageUsecase {
 				senderId.value,
 				receiverId.value,
 			);
-			if (block?.status === "blocked") {
+			if (block.isBlocked()) {
 				throw new ErrForbidden();
 			}
 

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, ForbiddenError, NotFoundError } from "@domain/error";
+import { ErrBadRequest, ErrForbidden, ErrNotFound } from "@domain/error";
 import { DirectMessage } from "@domain/model/direct_message";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -17,13 +17,13 @@ export class SendDirectMessageUsecase {
 		const receiverId = new UserId(input.receiverId);
 
 		if (senderId.equals(receiverId)) {
-			throw new BadRequestError({
+			throw new ErrBadRequest({
 				userMessage: "Cannot send a message to oneself.",
 			});
 		}
 
 		if (!input.content?.trim()) {
-			throw new BadRequestError({
+			throw new ErrBadRequest({
 				userMessage: "Message content cannot be empty.",
 			});
 		}
@@ -38,7 +38,7 @@ export class SendDirectMessageUsecase {
 			]);
 
 			if (!sender || !receiver) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			const friendshipRepo = repo.newFriendshipRepository();
@@ -47,7 +47,7 @@ export class SendDirectMessageUsecase {
 				receiverId.value,
 			);
 			if (block?.status === "blocked") {
-				throw new ForbiddenError();
+				throw new ErrForbidden();
 			}
 
 			const message = DirectMessage.create(sender, receiver, input.content);

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -13,8 +13,10 @@ export class SendDirectMessageUsecase {
 	constructor(private readonly transaction: ITransaction) {}
 
 	async execute(input: ISendDirectMessageUsecase): Promise<DirectMessage> {
-        if (input.senderId === input.receiverId) {
-			throw new ErrBadRequest( {userMessage: "自分自身にメッセージ送信することはできません。"} );
+		if (input.senderId === input.receiverId) {
+			throw new ErrBadRequest({
+				userMessage: "自分自身にメッセージ送信することはできません。",
+			});
 		}
 		const senderId = new UserId(input.senderId);
 		const receiverId = new UserId(input.receiverId);
@@ -37,11 +39,13 @@ export class SendDirectMessageUsecase {
 				senderId.value,
 				receiverId.value,
 			);
-            if (friendship) {
+			if (friendship) {
 				if (friendship.isBlocked()) {
 					throw new ErrForbidden();
-                }
-				throw new ErrBadRequest( { userMessage: "すでに友達になっているか、友達リクエストが存在します。" });
+				}
+				throw new ErrBadRequest({
+					userMessage: "すでに友達になっているか、友達リクエストが存在します。",
+				});
 			}
 
 			const message = DirectMessage.create(sender, receiver, input.content);

--- a/app/usecase/chat/send_direct_message_usecase.ts
+++ b/app/usecase/chat/send_direct_message_usecase.ts
@@ -1,4 +1,4 @@
-import { ErrBadRequest, ErrForbidden, ErrNotFound } from "@domain/error";
+import { ErrForbidden, ErrNotFound } from "@domain/error";
 import { DirectMessage } from "@domain/model/direct_message";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -15,18 +15,6 @@ export class SendDirectMessageUsecase {
 	async execute(input: ISendDirectMessageUsecase): Promise<DirectMessage> {
 		const senderId = new UserId(input.senderId);
 		const receiverId = new UserId(input.receiverId);
-
-		if (senderId.equals(receiverId)) {
-			throw new ErrBadRequest({
-				userMessage: "Cannot send a message to oneself.",
-			});
-		}
-
-		if (!input.content?.trim()) {
-			throw new ErrBadRequest({
-				userMessage: "Message content cannot be empty.",
-			});
-		}
 
 		return this.transaction.exec(async (repo) => {
 			const userRepository = repo.newUserRepository();

--- a/app/usecase/game/join_matchmaking_usecase.spec.ts
+++ b/app/usecase/game/join_matchmaking_usecase.spec.ts
@@ -20,7 +20,7 @@ describe("JoinMatchmakingUseCase", () => {
 	it("should successfully add a user to the matchmaking queue", async () => {
 		const userId = new UserId(ulid());
 		const userEmail = new UserEmail("test@example.com");
-		const user = User.reconstruct(userId, userEmail); // reconstructメソッドを想定
+		const user = User.reconstruct(userId, userEmail);
 
 		userRepository.findById.mockResolvedValue(user);
 

--- a/app/usecase/game/join_matchmaking_usecase.spec.ts
+++ b/app/usecase/game/join_matchmaking_usecase.spec.ts
@@ -1,7 +1,7 @@
 import { ulid } from "ulid";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
-import { NotFoundError } from "../../domain/error";
+import { ErrNotFound } from "../../domain/error";
 import { User, UserEmail, UserId } from "../../domain/model/user";
 import type { IUserRepository } from "../../domain/repository/user_repository";
 import type { MatchmakingService } from "../../domain/service/matchmaking_service";
@@ -30,12 +30,12 @@ describe("JoinMatchmakingUseCase", () => {
 		expect(matchmakingService.join).toHaveBeenCalledWith(user);
 	});
 
-	it("should throw NotFoundError if user is not found", async () => {
+	it("should throw ErrNotFound if user is not found", async () => {
 		const userIdValue = ulid();
 		const userId = new UserId(userIdValue);
 		userRepository.findById.mockResolvedValue(undefined);
 
-		await expect(useCase.execute(userIdValue)).rejects.toThrow(NotFoundError);
+		await expect(useCase.execute(userIdValue)).rejects.toThrow(ErrNotFound);
 		expect(userRepository.findById).toHaveBeenCalledWith(userId);
 	});
 });

--- a/app/usecase/game/join_matchmaking_usecase.spec.ts
+++ b/app/usecase/game/join_matchmaking_usecase.spec.ts
@@ -1,0 +1,41 @@
+import { ulid } from "ulid";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { NotFoundError } from "../../domain/error";
+import { User, UserEmail, UserId } from "../../domain/model/user";
+import type { IUserRepository } from "../../domain/repository/user_repository";
+import type { MatchmakingService } from "../../domain/service/matchmaking_service";
+import { JoinMatchmakingUseCase } from "./join_matchmaking_usecase";
+
+describe("JoinMatchmakingUseCase", () => {
+	const userRepository = mock<IUserRepository>();
+	const matchmakingService = mock<MatchmakingService>();
+	let useCase: JoinMatchmakingUseCase;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useCase = new JoinMatchmakingUseCase(userRepository, matchmakingService);
+	});
+
+	it("should successfully add a user to the matchmaking queue", async () => {
+		const userId = new UserId(ulid());
+		const userEmail = new UserEmail("test@example.com");
+		const user = User.reconstruct(userId, userEmail); // reconstructメソッドを想定
+
+		userRepository.findById.mockResolvedValue(user);
+
+		await useCase.execute(userId.value);
+
+		expect(userRepository.findById).toHaveBeenCalledWith(userId);
+		expect(matchmakingService.join).toHaveBeenCalledWith(user);
+	});
+
+	it("should throw NotFoundError if user is not found", async () => {
+		const userIdValue = ulid();
+		const userId = new UserId(userIdValue);
+		userRepository.findById.mockResolvedValue(undefined);
+
+		await expect(useCase.execute(userIdValue)).rejects.toThrow(NotFoundError);
+		expect(userRepository.findById).toHaveBeenCalledWith(userId);
+	});
+});

--- a/app/usecase/game/join_matchmaking_usecase.ts
+++ b/app/usecase/game/join_matchmaking_usecase.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "../../domain/error";
+import { ErrNotFound } from "../../domain/error";
 import { UserId } from "../../domain/model/user";
 import type { IUserRepository } from "../../domain/repository/user_repository";
 import type { MatchmakingService } from "../../domain/service/matchmaking_service";
@@ -14,7 +14,7 @@ export class JoinMatchmakingUseCase {
 		const user = await this.userRepository.findById(userId);
 
 		if (!user) {
-			throw new NotFoundError();
+			throw new ErrNotFound();
 		}
 		await this.matchmakingService.join(user);
 	}

--- a/app/usecase/game/join_matchmaking_usecase.ts
+++ b/app/usecase/game/join_matchmaking_usecase.ts
@@ -1,0 +1,21 @@
+import { NotFoundError } from "../../domain/error";
+import { UserId } from "../../domain/model/user";
+import type { IUserRepository } from "../../domain/repository/user_repository";
+import type { MatchmakingService } from "../../domain/service/matchmaking_service";
+
+export class JoinMatchmakingUseCase {
+	constructor(
+		private readonly userRepository: IUserRepository,
+		private readonly matchmakingService: MatchmakingService,
+	) {}
+
+	async execute(userIdValue: string): Promise<void> {
+		const userId = new UserId(userIdValue);
+		const user = await this.userRepository.findById(userId);
+
+		if (!user) {
+			throw new NotFoundError();
+		}
+		await this.matchmakingService.join(user);
+	}
+}

--- a/app/usecase/game/join_matchmaking_usecase.ts
+++ b/app/usecase/game/join_matchmaking_usecase.ts
@@ -1,4 +1,5 @@
 import { ErrNotFound } from "../../domain/error";
+import type { Match } from "../../domain/model/match";
 import { UserId } from "../../domain/model/user";
 import type { IUserRepository } from "../../domain/repository/user_repository";
 import type { MatchmakingService } from "../../domain/service/matchmaking_service";
@@ -9,13 +10,14 @@ export class JoinMatchmakingUseCase {
 		private readonly matchmakingService: MatchmakingService,
 	) {}
 
-	async execute(userIdValue: string): Promise<void> {
+	async execute(userIdValue: string): Promise<Match | undefined> {
 		const userId = new UserId(userIdValue);
 		const user = await this.userRepository.findById(userId);
 
 		if (!user) {
 			throw new ErrNotFound();
 		}
-		await this.matchmakingService.join(user);
+		const match = await this.matchmakingService.join(user);
+		return match ?? undefined;
 	}
 }

--- a/app/usecase/game/leave_matchmaking_usecase.spec.ts
+++ b/app/usecase/game/leave_matchmaking_usecase.spec.ts
@@ -1,0 +1,33 @@
+import { ulid } from "ulid";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import type { MatchmakingService } from "../../domain/service/matchmaking_service";
+import { LeaveMatchmakingUseCase } from "./leave_matchmaking_usecase";
+
+describe("LeaveMatchmakingUseCase", () => {
+	const matchmakingService = mock<MatchmakingService>();
+	let useCase: LeaveMatchmakingUseCase;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useCase = new LeaveMatchmakingUseCase(matchmakingService);
+	});
+
+	it("should call the leave method of matchmaking service with the correct user ID", async () => {
+		const userId = ulid();
+		matchmakingService.leave.mockResolvedValue(undefined);
+
+		await useCase.execute(userId);
+
+		expect(matchmakingService.leave).toHaveBeenCalledTimes(1);
+		expect(matchmakingService.leave).toHaveBeenCalledWith(userId);
+	});
+
+	it("should rethrow the error if the matchmaking service fails", async () => {
+		const userId = ulid();
+		const expectedError = new Error("User not in queue");
+		matchmakingService.leave.mockRejectedValue(expectedError);
+
+		await expect(useCase.execute(userId)).rejects.toThrow(expectedError);
+	});
+});

--- a/app/usecase/game/leave_matchmaking_usecase.ts
+++ b/app/usecase/game/leave_matchmaking_usecase.ts
@@ -1,0 +1,9 @@
+import type { MatchmakingService } from "../../domain/service/matchmaking_service";
+
+export class LeaveMatchmakingUseCase {
+	constructor(private readonly matchmakingService: MatchmakingService) {}
+
+	async execute(userId: string): Promise<void> {
+		await this.matchmakingService.leave(userId);
+	}
+}

--- a/app/usecase/game/leave_matchmaking_usecase.ts
+++ b/app/usecase/game/leave_matchmaking_usecase.ts
@@ -1,4 +1,4 @@
-import type { MatchmakingService } from "../../domain/service/matchmaking_service";
+import type { MatchmakingService } from "@domain/service/matchmaking_service";
 
 export class LeaveMatchmakingUseCase {
 	constructor(private readonly matchmakingService: MatchmakingService) {}

--- a/app/usecase/relationship/block_user_usecase.ts
+++ b/app/usecase/relationship/block_user_usecase.ts
@@ -1,0 +1,54 @@
+import { BadRequestError, NotFoundError } from "@domain/error";
+import { Friendship } from "@domain/model/friendship";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface IBlockUserUsecase {
+	blockerId: string;
+	blockedId: string;
+}
+
+export class BlockUserUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: IBlockUserUsecase): Promise<void> {
+		const blockerId = new UserId(input.blockerId);
+		const blockedId = new UserId(input.blockedId);
+
+		if (blockerId.equals(blockedId)) {
+			throw new BadRequestError({ userMessage: "Cannot block oneself." });
+		}
+
+		await this.transaction.exec(async (repo) => {
+			const userRepository = repo.newUserRepository();
+			const friendshipRepository = repo.newFriendshipRepository();
+
+			const [blocker, blocked] = await Promise.all([
+				userRepository.findById(blockerId),
+				userRepository.findById(blockedId),
+			]);
+
+			if (!blocker || !blocked) {
+				throw new NotFoundError();
+			}
+
+			let friendship = await friendshipRepository.findByUserIds(
+				blockerId.value,
+				blockedId.value,
+			);
+
+			if (friendship) {
+				if (friendship.status === "blocked") {
+					return; // Already blocked
+				}
+				friendship.status = "blocked";
+			} else {
+				// Create a new friendship with blocked status
+				friendship = Friendship.create(blocker, blocked);
+				friendship.status = "blocked";
+			}
+
+			await friendshipRepository.save(friendship);
+		});
+	}
+}

--- a/app/usecase/relationship/block_user_usecase.ts
+++ b/app/usecase/relationship/block_user_usecase.ts
@@ -3,10 +3,10 @@ import { Friendship } from "@domain/model/friendship";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface IBlockUserUsecase {
+type IBlockUserUsecase = {
 	blockerId: string;
 	blockedId: string;
-}
+};
 
 export class BlockUserUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/relationship/block_user_usecase.ts
+++ b/app/usecase/relationship/block_user_usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, NotFoundError } from "@domain/error";
+import { ErrBadRequest, ErrNotFound } from "@domain/error";
 import { Friendship } from "@domain/model/friendship";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -16,7 +16,7 @@ export class BlockUserUsecase {
 		const blockedId = new UserId(input.blockedId);
 
 		if (blockerId.equals(blockedId)) {
-			throw new BadRequestError({ userMessage: "Cannot block oneself." });
+			throw new ErrBadRequest({ userMessage: "Cannot block oneself." });
 		}
 
 		await this.transaction.exec(async (repo) => {
@@ -29,7 +29,7 @@ export class BlockUserUsecase {
 			]);
 
 			if (!blocker || !blocked) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			let friendship = await friendshipRepository.findByUserIds(

--- a/app/usecase/relationship/block_user_usecase.ts
+++ b/app/usecase/relationship/block_user_usecase.ts
@@ -38,14 +38,13 @@ export class BlockUserUsecase {
 			);
 
 			if (friendship) {
-				if (friendship.status === "blocked") {
-					return; // Already blocked
+				if (friendship.isBlocked()) {
+					return;
 				}
-				friendship.status = "blocked";
+				friendship.block();
 			} else {
-				// Create a new friendship with blocked status
 				friendship = Friendship.create(blocker, blocked);
-				friendship.status = "blocked";
+				friendship.block();
 			}
 
 			await friendshipRepository.save(friendship);

--- a/app/usecase/relationship/get_friends_usecase.ts
+++ b/app/usecase/relationship/get_friends_usecase.ts
@@ -1,0 +1,24 @@
+import { NotFoundError } from "@domain/error";
+import type { User } from "@domain/model/user";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+export class GetFriendsUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(userIdValue: string): Promise<User[]> {
+		const userId = new UserId(userIdValue);
+
+		return this.transaction.exec(async (repo) => {
+			const userRepository = repo.newUserRepository();
+			const friendshipRepository = repo.newFriendshipRepository();
+
+			const user = await userRepository.findById(userId);
+			if (!user) {
+				throw new NotFoundError();
+			}
+
+			return friendshipRepository.findFriendsByUserId(userId.value);
+		});
+	}
+}

--- a/app/usecase/relationship/get_friends_usecase.ts
+++ b/app/usecase/relationship/get_friends_usecase.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "@domain/error";
+import { ErrNotFound } from "@domain/error";
 import type { User } from "@domain/model/user";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -15,7 +15,7 @@ export class GetFriendsUsecase {
 
 			const user = await userRepository.findById(userId);
 			if (!user) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			return friendshipRepository.findFriendsByUserId(userId.value);

--- a/app/usecase/relationship/relationship_usecase.spec.ts
+++ b/app/usecase/relationship/relationship_usecase.spec.ts
@@ -1,0 +1,359 @@
+import { BadRequestError, ForbiddenError, NotFoundError } from "@domain/error";
+import { Friendship } from "@domain/model/friendship";
+import { User, UserEmail } from "@domain/model/user";
+import type { IFriendshipRepository } from "@domain/repository/friendship_repository";
+import type { IUserRepository } from "@domain/repository/user_repository";
+import type { ITransaction } from "@usecase/transaction";
+import { ulid } from "ulid";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { BlockUserUsecase } from "./block_user_usecase";
+import { GetFriendsUsecase } from "./get_friends_usecase";
+import { RemoveFriendUsecase } from "./remove_friend_usecase";
+import { RespondToFriendRequestUsecase } from "./respond_to_friend_request_usecase";
+import { SendFriendRequestUsecase } from "./send_friend_request_usecase";
+import { UnblockUserUsecase } from "./unblock_user_usecase";
+
+// --- Common Mocks & Setup ---
+const userRepo = mock<IUserRepository>();
+const friendshipRepo = mock<IFriendshipRepository>();
+const tx = mock<ITransaction>();
+
+// トランザクションのモック実装
+const mockRepos = {
+	newUserRepository: () => userRepo,
+	newFriendshipRepository: () => friendshipRepo,
+};
+tx.exec.mockImplementation(async (callback) => callback(mockRepos));
+
+// 各テストの前にモックをクリア
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+// --- Test Suites ---
+
+describe("SendFriendRequestUsecase", () => {
+	const usecase = new SendFriendRequestUsecase(tx);
+	const requester = User.create(new UserEmail("requester@example.com"));
+	const receiver = User.create(new UserEmail("receiver@example.com"));
+
+	it("should create a pending friendship when no relationship exists", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(requester)
+			.mockResolvedValueOnce(receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(undefined);
+
+		await usecase.execute({
+			requesterId: requester.id.value,
+			receiverId: receiver.id.value,
+		});
+
+		expect(friendshipRepo.save).toHaveBeenCalledOnce();
+		expect(friendshipRepo.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requesterId: requester.id,
+				receiverId: receiver.id,
+				status: "pending",
+			}),
+		);
+	});
+
+	it("should throw BadRequestError if friendship already exists", async () => {
+		const existingFriendship = Friendship.create(requester, receiver);
+		userRepo.findById
+			.mockResolvedValueOnce(requester)
+			.mockResolvedValueOnce(receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(existingFriendship);
+
+		await expect(
+			usecase.execute({
+				requesterId: requester.id.value,
+				receiverId: receiver.id.value,
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError when sending a request to oneself", async () => {
+		await expect(
+			usecase.execute({
+				requesterId: requester.id.value,
+				receiverId: requester.id.value,
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw NotFoundError if receiver does not exist", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(requester)
+			.mockResolvedValueOnce(undefined);
+		await expect(
+			usecase.execute({
+				requesterId: requester.id.value,
+				receiverId: ulid(),
+			}),
+		).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe("RespondToFriendRequestUsecase", () => {
+	const usecase = new RespondToFriendRequestUsecase(tx);
+	const requester = User.create(new UserEmail("requester@example.com"));
+	const receiver = User.create(new UserEmail("receiver@example.com"));
+	const otherUser = User.create(new UserEmail("other@example.com"));
+
+	it("should accept a pending friend request", async () => {
+		const pendingFriendship = Friendship.create(requester, receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(pendingFriendship);
+
+		await usecase.execute({
+			receiverId: receiver.id.value,
+			requesterId: requester.id.value,
+			response: "accept",
+		});
+
+		expect(friendshipRepo.save).toHaveBeenCalledOnce();
+		expect(friendshipRepo.save).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "accepted" }),
+		);
+	});
+
+	it("should reject and delete a pending friend request", async () => {
+		const pendingFriendship = Friendship.create(requester, receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(pendingFriendship);
+
+		await usecase.execute({
+			receiverId: receiver.id.value,
+			requesterId: requester.id.value,
+			response: "reject",
+		});
+
+		expect(friendshipRepo.delete).toHaveBeenCalledOnce();
+		expect(friendshipRepo.delete).toHaveBeenCalledWith(pendingFriendship);
+	});
+
+	it("should throw NotFoundError if the friend request does not exist", async () => {
+		friendshipRepo.findByUserIds.mockResolvedValue(null);
+		await expect(
+			usecase.execute({
+				receiverId: receiver.id.value,
+				requesterId: requester.id.value,
+				response: "accept",
+			}),
+		).rejects.toThrow(NotFoundError);
+	});
+
+	it("should throw ForbiddenError if the request is not pending", async () => {
+		const acceptedFriendship = Friendship.create(requester, receiver);
+		acceptedFriendship.accept();
+		friendshipRepo.findByUserIds.mockResolvedValue(acceptedFriendship);
+
+		await expect(
+			usecase.execute({
+				receiverId: receiver.id.value,
+				requesterId: requester.id.value,
+				response: "accept",
+			}),
+		).rejects.toThrow(ForbiddenError);
+	});
+
+	it("should throw ForbiddenError if a user other than the receiver tries to respond", async () => {
+		const pendingFriendship = Friendship.create(requester, receiver);
+		friendshipRepo.findByUserIds.mockResolvedValue(pendingFriendship);
+
+		await expect(
+			usecase.execute({
+				receiverId: otherUser.id.value, // Wrong user
+				requesterId: requester.id.value,
+				response: "accept",
+			}),
+		).rejects.toThrow(ForbiddenError);
+	});
+});
+
+describe("GetFriendsUsecase", () => {
+	const usecase = new GetFriendsUsecase(tx);
+	const user = User.create(new UserEmail("user@example.com"));
+	const friend1 = User.create(new UserEmail("friend1@example.com"));
+	const friend2 = User.create(new UserEmail("friend2@example.com"));
+
+	it("should return a list of friends", async () => {
+		userRepo.findById.mockResolvedValue(user);
+		friendshipRepo.findFriendsByUserId.mockResolvedValue([friend1, friend2]);
+
+		const friends = await usecase.execute(user.id.value);
+
+		expect(friends).toHaveLength(2);
+		expect(friends).toEqual(expect.arrayContaining([friend1, friend2]));
+	});
+
+	it("should return an empty list if the user has no friends", async () => {
+		userRepo.findById.mockResolvedValue(user);
+		friendshipRepo.findFriendsByUserId.mockResolvedValue([]);
+
+		const friends = await usecase.execute(user.id.value);
+		expect(friends).toHaveLength(0);
+	});
+
+	it("should throw NotFoundError if the user does not exist", async () => {
+		userRepo.findById.mockResolvedValue(undefined);
+		await expect(usecase.execute(ulid())).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe("RemoveFriendUsecase", () => {
+	const usecase = new RemoveFriendUsecase(tx);
+	const user = User.create(new UserEmail("user@example.com"));
+	const friend = User.create(new UserEmail("friend@example.com"));
+
+	it("should remove a friend successfully", async () => {
+		const friendship = Friendship.create(user, friend);
+		friendship.accept();
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await usecase.execute({
+			userId: user.id.value,
+			friendId: friend.id.value,
+		});
+
+		expect(friendshipRepo.delete).toHaveBeenCalledWith(friendship);
+	});
+
+	it("should throw NotFoundError if the friendship does not exist", async () => {
+		friendshipRepo.findByUserIds.mockResolvedValue(null);
+		await expect(
+			usecase.execute({ userId: user.id.value, friendId: friend.id.value }),
+		).rejects.toThrow(NotFoundError);
+	});
+
+	it("should throw NotFoundError if the friendship is pending, not accepted", async () => {
+		const friendship = Friendship.create(user, friend); // status is 'pending'
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+		await expect(
+			usecase.execute({ userId: user.id.value, friendId: friend.id.value }),
+		).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe("BlockUserUsecase", () => {
+	const usecase = new BlockUserUsecase(tx);
+	const blocker = User.create(new UserEmail("blocker@example.com"));
+	const blocked = User.create(new UserEmail("blocked@example.com"));
+
+	it("should create a new relationship with 'blocked' status", async () => {
+		userRepo.findById
+			.mockResolvedValueOnce(blocker)
+			.mockResolvedValueOnce(blocked);
+		friendshipRepo.findByUserIds.mockResolvedValue(undefined);
+
+		await usecase.execute({
+			blockerId: blocker.id.value,
+			blockedId: blocked.id.value,
+		});
+
+		expect(friendshipRepo.save).toHaveBeenCalledOnce();
+		expect(friendshipRepo.save).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "blocked" }),
+		);
+	});
+
+	it("should update an existing friendship to 'blocked'", async () => {
+		const friendship = Friendship.create(blocker, blocked);
+		friendship.accept();
+		userRepo.findById
+			.mockResolvedValueOnce(blocker)
+			.mockResolvedValueOnce(blocked);
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await usecase.execute({
+			blockerId: blocker.id.value,
+			blockedId: blocked.id.value,
+		});
+
+		expect(friendshipRepo.save).toHaveBeenCalledOnce();
+		expect(friendshipRepo.save).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "blocked" }),
+		);
+	});
+
+	it("should not do anything if user is already blocked", async () => {
+		const friendship = Friendship.create(blocker, blocked);
+		friendship.status = "blocked";
+		userRepo.findById
+			.mockResolvedValueOnce(blocker)
+			.mockResolvedValueOnce(blocked);
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await usecase.execute({
+			blockerId: blocker.id.value,
+			blockedId: blocked.id.value,
+		});
+
+		expect(friendshipRepo.save).not.toHaveBeenCalled();
+	});
+
+	it("should throw BadRequestError when blocking oneself", async () => {
+		await expect(
+			usecase.execute({
+				blockerId: blocker.id.value,
+				blockedId: blocker.id.value,
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+});
+
+describe("UnblockUserUsecase", () => {
+	const usecase = new UnblockUserUsecase(tx);
+	const blocker = User.create(new UserEmail("blocker@example.com"));
+	const blocked = User.create(new UserEmail("blocked@example.com"));
+	const otherUser = User.create(new UserEmail("other@example.com"));
+
+	it("should unblock a user by deleting the relationship", async () => {
+		const friendship = Friendship.create(blocker, blocked);
+		friendship.status = "blocked";
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await usecase.execute({
+			blockerId: blocker.id.value,
+			blockedId: blocked.id.value,
+		});
+
+		expect(friendshipRepo.delete).toHaveBeenCalledWith(friendship);
+	});
+
+	it("should throw NotFoundError if no block relationship exists", async () => {
+		friendshipRepo.findByUserIds.mockResolvedValue(null);
+		await expect(
+			usecase.execute({
+				blockerId: blocker.id.value,
+				blockedId: blocked.id.value,
+			}),
+		).rejects.toThrow(NotFoundError);
+	});
+
+	it("should throw NotFoundError if the relationship is not 'blocked'", async () => {
+		const friendship = Friendship.create(blocker, blocked);
+		friendship.accept();
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await expect(
+			usecase.execute({
+				blockerId: blocker.id.value,
+				blockedId: blocked.id.value,
+			}),
+		).rejects.toThrow(NotFoundError);
+	});
+
+	it("should throw NotFoundError if a user other than the blocker tries to unblock", async () => {
+		const friendship = Friendship.create(blocker, blocked);
+		friendship.status = "blocked";
+		friendshipRepo.findByUserIds.mockResolvedValue(friendship);
+
+		await expect(
+			usecase.execute({
+				blockerId: otherUser.id.value, // Wrong user
+				blockedId: blocked.id.value,
+			}),
+		).rejects.toThrow(NotFoundError);
+	});
+});

--- a/app/usecase/relationship/remove_friend_usecase.ts
+++ b/app/usecase/relationship/remove_friend_usecase.ts
@@ -2,10 +2,10 @@ import { ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface IRemoveFriendUsecase {
+type IRemoveFriendUsecase = {
 	userId: string;
 	friendId: string;
-}
+};
 
 export class RemoveFriendUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/relationship/remove_friend_usecase.ts
+++ b/app/usecase/relationship/remove_friend_usecase.ts
@@ -1,0 +1,31 @@
+import { NotFoundError } from "@domain/error";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface IRemoveFriendUsecase {
+	userId: string;
+	friendId: string;
+}
+
+export class RemoveFriendUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: IRemoveFriendUsecase): Promise<void> {
+		const userId = new UserId(input.userId);
+		const friendId = new UserId(input.friendId);
+
+		await this.transaction.exec(async (repo) => {
+			const friendshipRepository = repo.newFriendshipRepository();
+			const friendship = await friendshipRepository.findByUserIds(
+				userId.value,
+				friendId.value,
+			);
+
+			if (!friendship || !friendship.isAccepted()) {
+				throw new NotFoundError();
+			}
+
+			await friendshipRepository.delete(friendship);
+		});
+	}
+}

--- a/app/usecase/relationship/remove_friend_usecase.ts
+++ b/app/usecase/relationship/remove_friend_usecase.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "@domain/error";
+import { ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
@@ -22,7 +22,7 @@ export class RemoveFriendUsecase {
 			);
 
 			if (!friendship || !friendship.isAccepted()) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			await friendshipRepository.delete(friendship);

--- a/app/usecase/relationship/respond_to_friend_request_usecase.ts
+++ b/app/usecase/relationship/respond_to_friend_request_usecase.ts
@@ -6,7 +6,7 @@ type IRespondToFriendRequestUsecase = {
 	receiverId: string; // The user responding to the request
 	requesterId: string; // The user who sent the request
 	response: "accept" | "reject";
-}
+};
 
 export class RespondToFriendRequestUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/relationship/respond_to_friend_request_usecase.ts
+++ b/app/usecase/relationship/respond_to_friend_request_usecase.ts
@@ -2,7 +2,7 @@ import { ErrForbidden, ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface IRespondToFriendRequestUsecase {
+type IRespondToFriendRequestUsecase = {
 	receiverId: string; // The user responding to the request
 	requesterId: string; // The user who sent the request
 	response: "accept" | "reject";

--- a/app/usecase/relationship/respond_to_friend_request_usecase.ts
+++ b/app/usecase/relationship/respond_to_friend_request_usecase.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, NotFoundError } from "@domain/error";
+import { ErrForbidden, ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
@@ -23,7 +23,7 @@ export class RespondToFriendRequestUsecase {
 			);
 
 			if (!friendship) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			// Ensure the request is pending and the correct user is responding
@@ -31,7 +31,7 @@ export class RespondToFriendRequestUsecase {
 				friendship.status !== "pending" ||
 				!friendship.receiverId.equals(receiverId)
 			) {
-				throw new ForbiddenError();
+				throw new ErrForbidden();
 			}
 
 			if (input.response === "accept") {

--- a/app/usecase/relationship/respond_to_friend_request_usecase.ts
+++ b/app/usecase/relationship/respond_to_friend_request_usecase.ts
@@ -1,0 +1,45 @@
+import { ForbiddenError, NotFoundError } from "@domain/error";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface IRespondToFriendRequestUsecase {
+	receiverId: string; // The user responding to the request
+	requesterId: string; // The user who sent the request
+	response: "accept" | "reject";
+}
+
+export class RespondToFriendRequestUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: IRespondToFriendRequestUsecase): Promise<void> {
+		const receiverId = new UserId(input.receiverId);
+		const requesterId = new UserId(input.requesterId);
+
+		await this.transaction.exec(async (repo) => {
+			const friendshipRepository = repo.newFriendshipRepository();
+			const friendship = await friendshipRepository.findByUserIds(
+				requesterId.value,
+				receiverId.value,
+			);
+
+			if (!friendship) {
+				throw new NotFoundError();
+			}
+
+			// Ensure the request is pending and the correct user is responding
+			if (
+				friendship.status !== "pending" ||
+				!friendship.receiverId.equals(receiverId)
+			) {
+				throw new ForbiddenError();
+			}
+
+			if (input.response === "accept") {
+				friendship.accept();
+				await friendshipRepository.save(friendship);
+			} else {
+				await friendshipRepository.delete(friendship);
+			}
+		});
+	}
+}

--- a/app/usecase/relationship/send_friend_request_usecase.ts
+++ b/app/usecase/relationship/send_friend_request_usecase.ts
@@ -1,4 +1,4 @@
-import { ErrBadRequest, ErrNotFound } from "@domain/error";
+import { ErrBadRequest, ErrForbidden, ErrNotFound } from "@domain/error";
 import { Friendship } from "@domain/model/friendship";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -40,6 +40,9 @@ export class SendFriendRequestUsecase {
 			);
 
 			if (existingFriendship) {
+				if (existingFriendship.status === "blocked") {
+					throw new ErrForbidden();
+				}
 				throw new ErrBadRequest({
 					userMessage: "Friendship already exists or is pending.",
 				});

--- a/app/usecase/relationship/send_friend_request_usecase.ts
+++ b/app/usecase/relationship/send_friend_request_usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, NotFoundError } from "@domain/error";
+import { ErrBadRequest, ErrNotFound } from "@domain/error";
 import { Friendship } from "@domain/model/friendship";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
@@ -16,7 +16,7 @@ export class SendFriendRequestUsecase {
 		const receiverId = new UserId(input.receiverId);
 
 		if (requesterId.equals(receiverId)) {
-			throw new BadRequestError({
+			throw new ErrBadRequest({
 				userMessage: "Cannot send a friend request to oneself.",
 			});
 		}
@@ -31,7 +31,7 @@ export class SendFriendRequestUsecase {
 			]);
 
 			if (!requester || !receiver) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			const existingFriendship = await friendshipRepository.findByUserIds(
@@ -40,7 +40,7 @@ export class SendFriendRequestUsecase {
 			);
 
 			if (existingFriendship) {
-				throw new BadRequestError({
+				throw new ErrBadRequest({
 					userMessage: "Friendship already exists or is pending.",
 				});
 			}

--- a/app/usecase/relationship/send_friend_request_usecase.ts
+++ b/app/usecase/relationship/send_friend_request_usecase.ts
@@ -17,7 +17,7 @@ export class SendFriendRequestUsecase {
 
 		if (requesterId.equals(receiverId)) {
 			throw new ErrBadRequest({
-				userMessage: "Cannot send a friend request to oneself.",
+				userMessage: "自分自身に友達リクエストを送ることはできません。",
 			});
 		}
 
@@ -40,11 +40,11 @@ export class SendFriendRequestUsecase {
 			);
 
 			if (existingFriendship) {
-				if (existingFriendship.status === "blocked") {
+				if (existingFriendship.isBlocked()) {
 					throw new ErrForbidden();
 				}
 				throw new ErrBadRequest({
-					userMessage: "Friendship already exists or is pending.",
+					userMessage: "フレンドシップが既に存在するか、保留中です。",
 				});
 			}
 

--- a/app/usecase/relationship/send_friend_request_usecase.ts
+++ b/app/usecase/relationship/send_friend_request_usecase.ts
@@ -1,0 +1,52 @@
+import { BadRequestError, NotFoundError } from "@domain/error";
+import { Friendship } from "@domain/model/friendship";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface ISendFriendRequestUsecase {
+	requesterId: string;
+	receiverId: string;
+}
+
+export class SendFriendRequestUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: ISendFriendRequestUsecase): Promise<void> {
+		const requesterId = new UserId(input.requesterId);
+		const receiverId = new UserId(input.receiverId);
+
+		if (requesterId.equals(receiverId)) {
+			throw new BadRequestError({
+				userMessage: "Cannot send a friend request to oneself.",
+			});
+		}
+
+		await this.transaction.exec(async (repo) => {
+			const userRepository = repo.newUserRepository();
+			const friendshipRepository = repo.newFriendshipRepository();
+
+			const [requester, receiver] = await Promise.all([
+				userRepository.findById(requesterId),
+				userRepository.findById(receiverId),
+			]);
+
+			if (!requester || !receiver) {
+				throw new NotFoundError();
+			}
+
+			const existingFriendship = await friendshipRepository.findByUserIds(
+				requesterId.value,
+				receiverId.value,
+			);
+
+			if (existingFriendship) {
+				throw new BadRequestError({
+					userMessage: "Friendship already exists or is pending.",
+				});
+			}
+
+			const friendship = Friendship.create(requester, receiver);
+			await friendshipRepository.save(friendship);
+		});
+	}
+}

--- a/app/usecase/relationship/send_friend_request_usecase.ts
+++ b/app/usecase/relationship/send_friend_request_usecase.ts
@@ -3,10 +3,10 @@ import { Friendship } from "@domain/model/friendship";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface ISendFriendRequestUsecase {
+type ISendFriendRequestUsecase = {
 	requesterId: string;
 	receiverId: string;
-}
+};
 
 export class SendFriendRequestUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/relationship/unblock_user_usecase.ts
+++ b/app/usecase/relationship/unblock_user_usecase.ts
@@ -1,0 +1,37 @@
+import { NotFoundError } from "@domain/error";
+import { UserId } from "@domain/model/user";
+import type { ITransaction } from "@usecase/transaction";
+
+interface IUnblockUserUsecase {
+	blockerId: string;
+	blockedId: string;
+}
+
+export class UnblockUserUsecase {
+	constructor(private readonly transaction: ITransaction) {}
+
+	async execute(input: IUnblockUserUsecase): Promise<void> {
+		const blockerId = new UserId(input.blockerId);
+		const blockedId = new UserId(input.blockedId);
+
+		await this.transaction.exec(async (repo) => {
+			const friendshipRepository = repo.newFriendshipRepository();
+			const friendship = await friendshipRepository.findByUserIds(
+				blockerId.value,
+				blockedId.value,
+			);
+
+			// Only the blocker can unblock, and status must be 'blocked'
+			if (
+				!friendship ||
+				friendship.status !== "blocked" ||
+				!friendship.requesterId.equals(blockerId)
+			) {
+				throw new NotFoundError();
+			}
+
+			// Unblocking removes the relationship entirely
+			await friendshipRepository.delete(friendship);
+		});
+	}
+}

--- a/app/usecase/relationship/unblock_user_usecase.ts
+++ b/app/usecase/relationship/unblock_user_usecase.ts
@@ -2,10 +2,10 @@ import { ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
-interface IUnblockUserUsecase {
+type IUnblockUserUsecase = {
 	blockerId: string;
 	blockedId: string;
-}
+};
 
 export class UnblockUserUsecase {
 	constructor(private readonly transaction: ITransaction) {}

--- a/app/usecase/relationship/unblock_user_usecase.ts
+++ b/app/usecase/relationship/unblock_user_usecase.ts
@@ -21,12 +21,13 @@ export class UnblockUserUsecase {
 				blockedId.value,
 			);
 
-			// Only the blocker can unblock, and status must be 'blocked'
-			if (
-				!friendship ||
-				friendship.status !== "blocked" ||
-				!friendship.requesterId.equals(blockerId)
-			) {
+			if (!friendship || !friendship.requesterId.equals(blockerId)) {
+				throw new ErrNotFound();
+			}
+
+			try {
+				friendship.unblock();
+			} catch (_e) {
 				throw new ErrNotFound();
 			}
 

--- a/app/usecase/relationship/unblock_user_usecase.ts
+++ b/app/usecase/relationship/unblock_user_usecase.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "@domain/error";
+import { ErrNotFound } from "@domain/error";
 import { UserId } from "@domain/model/user";
 import type { ITransaction } from "@usecase/transaction";
 
@@ -27,7 +27,7 @@ export class UnblockUserUsecase {
 				friendship.status !== "blocked" ||
 				!friendship.requesterId.equals(blockerId)
 			) {
-				throw new NotFoundError();
+				throw new ErrNotFound();
 			}
 
 			// Unblocking removes the relationship entirely

--- a/app/usecase/user/delete_user_usecase.spec.ts
+++ b/app/usecase/user/delete_user_usecase.spec.ts
@@ -1,6 +1,11 @@
+// ==> app/usecase/user/delete_user_usecase.spec.ts <==
 import { ErrNotFound } from "@domain/error";
 import { User, UserEmail } from "@domain/model";
-import type { IUserRepository } from "@domain/repository";
+import type {
+	IDirectMessageRepository,
+	IFriendshipRepository,
+	IUserRepository,
+} from "@domain/repository";
 import type { ITransaction } from "@usecase/transaction";
 import { ulid } from "ulid";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -22,6 +27,8 @@ describe("DeleteUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});
@@ -43,6 +50,8 @@ describe("DeleteUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});

--- a/app/usecase/user/update_user_usecase.spec.ts
+++ b/app/usecase/user/update_user_usecase.spec.ts
@@ -1,6 +1,11 @@
+// ==> app/usecase/user/update_user_usecase.spec.ts <==
 import { ErrBadRequest, ErrNotFound } from "@domain/error";
 import { User, UserEmail } from "@domain/model";
-import type { IUserRepository } from "@domain/repository";
+import type {
+	IDirectMessageRepository,
+	IFriendshipRepository,
+	IUserRepository,
+} from "@domain/repository";
 import type { ITransaction } from "@usecase/transaction";
 import { ulid } from "ulid";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +28,8 @@ describe("UpdateUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});
@@ -46,6 +53,8 @@ describe("UpdateUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});
@@ -71,6 +80,8 @@ describe("UpdateUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});
@@ -96,6 +107,8 @@ describe("UpdateUserUsecase", () => {
 		mockTx.exec.mockImplementation(async (callback) => {
 			const repo = {
 				newUserRepository: () => mockUserRepo,
+				newFriendshipRepository: () => mock<IFriendshipRepository>(),
+				newDirectMessageRepository: () => mock<IDirectMessageRepository>(),
 			};
 			return callback(repo);
 		});

--- a/prisma/migrations/20250823094740_pong_game_logic/migration.sql
+++ b/prisma/migrations/20250823094740_pong_game_logic/migration.sql
@@ -1,0 +1,72 @@
+-- CreateTable
+CREATE TABLE "Friendship" (
+    "requesterId" TEXT NOT NULL,
+    "receiverId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+
+    PRIMARY KEY ("requesterId", "receiverId"),
+    CONSTRAINT "Friendship_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Friendship_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DirectMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "senderId" TEXT NOT NULL,
+    "receiverId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "sentAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DirectMessage_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "DirectMessage_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Match" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "status" TEXT NOT NULL,
+    "gameType" TEXT NOT NULL DEFAULT 'Pong',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "MatchParticipant" (
+    "matchId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    PRIMARY KEY ("matchId", "userId"),
+    CONSTRAINT "MatchParticipant_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "MatchParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "MatchHistory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "winnerId" TEXT NOT NULL,
+    "loserId" TEXT NOT NULL,
+    "winnerScore" INTEGER NOT NULL,
+    "loserScore" INTEGER NOT NULL,
+    "playedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MatchHistory_winnerId_fkey" FOREIGN KEY ("winnerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "MatchHistory_loserId_fkey" FOREIGN KEY ("loserId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'offline',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "updatedAt") SELECT "createdAt", "email", "id", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20250829031313_add_match_history_relation/migration.sql
+++ b/prisma/migrations/20250829031313_add_match_history_relation/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - Added the required column `matchId` to the `MatchHistory` table without a default value. This is not possible if the table is not empty.
+  - Made the column `email` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_MatchHistory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "matchId" TEXT NOT NULL,
+    "winnerId" TEXT NOT NULL,
+    "loserId" TEXT NOT NULL,
+    "winnerScore" INTEGER NOT NULL,
+    "loserScore" INTEGER NOT NULL,
+    "playedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MatchHistory_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "MatchHistory_winnerId_fkey" FOREIGN KEY ("winnerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "MatchHistory_loserId_fkey" FOREIGN KEY ("loserId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_MatchHistory" ("id", "loserId", "loserScore", "playedAt", "winnerId", "winnerScore") SELECT "id", "loserId", "loserScore", "playedAt", "winnerId", "winnerScore" FROM "MatchHistory";
+DROP TABLE "MatchHistory";
+ALTER TABLE "new_MatchHistory" RENAME TO "MatchHistory";
+CREATE UNIQUE INDEX "MatchHistory_matchId_key" ON "MatchHistory"("matchId");
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'offline',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "status", "updatedAt") SELECT "createdAt", "email", "id", "status", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 
 model User {
   id            String    @id
-  email         String?   @unique
+  email         String    @unique
   status        String    @default("offline") // "online" or "offline"
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Match {
   updatedAt DateTime @updatedAt
 
   participants MatchParticipant[]
+  history      MatchHistory?
 }
 
 // MatchとUserの多対多を表現する中間テーブル
@@ -82,12 +83,14 @@ model MatchParticipant {
 
 model MatchHistory {
   id          String   @id
+  matchId     String   @unique
   winnerId    String
   loserId     String
   winnerScore Int
   loserScore  Int
   playedAt    DateTime @default(now())
 
+  match  Match  @relation(fields: [matchId], references: [id])
   winner User @relation("Winner", fields: [winnerId], references: [id])
   loser  User @relation("Loser", fields: [loserId], references: [id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,8 +12,82 @@ datasource db {
 }
 
 model User {
-  id    String     @id
-  email String  @unique
+  id            String    @id
+  email         String?   @unique
+  status        String    @default("offline") // "online" or "offline"
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  // Friendship relations
+  sentFriendRequests     Friendship[] @relation("Requester")
+  receivedFriendRequests Friendship[] @relation("Receiver")
+
+  // DirectMessage relations
+  sentMessages     DirectMessage[] @relation("Sender")
+  receivedMessages DirectMessage[] @relation("Receiver")
+
+  // Match relations
+  matchParticipants MatchParticipant[]
+
+  // MatchHistory relations
+  wonMatches  MatchHistory[] @relation("Winner")
+  lostMatches MatchHistory[] @relation("Loser")
+}
+
+model Friendship {
+  requesterId String
+  receiverId  String
+  status      String // "pending", "accepted", "blocked"
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  requester User @relation("Requester", fields: [requesterId], references: [id])
+  receiver  User @relation("Receiver", fields: [receiverId], references: [id])
+
+  @@id([requesterId, receiverId])
+}
+
+model DirectMessage {
+  id         String   @id
+  senderId   String
+  receiverId String
+  content    String
+  isRead     Boolean  @default(false)
+  sentAt     DateTime @default(now())
+
+  sender   User @relation("Sender", fields: [senderId], references: [id])
+  receiver User @relation("Receiver", fields: [receiverId], references: [id])
+}
+
+model Match {
+  id        String   @id
+  status    String // "in_progress", "completed"
+  gameType  String   @default("Pong")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  participants MatchParticipant[]
+}
+
+// MatchとUserの多対多を表現する中間テーブル
+model MatchParticipant {
+  matchId String
+  userId  String
+
+  match Match @relation(fields: [matchId], references: [id])
+  user  User  @relation(fields: [userId], references: [id])
+
+  @@id([matchId, userId])
+}
+
+model MatchHistory {
+  id          String   @id
+  winnerId    String
+  loserId     String
+  winnerScore Int
+  loserScore  Int
+  playedAt    DateTime @default(now())
+
+  winner User @relation("Winner", fields: [winnerId], references: [id])
+  loser  User @relation("Loser", fields: [loserId], references: [id])
 }


### PR DESCRIPTION
### やったこと
アプリケーションの機能（フレンド、チャット、ゲームマッチング）の基本部分を実装しました。

  バックエンド
   - フレンド機能: フレンド申請・承認・削除・ブロックに関するAPI群を実装
   - チャット機能: ダイレクトメッセージの送受信・履歴取得APIを実装
   - ゲーム機能: マッチメイキングへの参加・離脱APIを実装
   - 上記機能を実現するためのドメイン層、ユースケース層、インフラ層を設計・実装

  データベース
   - Pongのゲームロジックに関連するテーブル定義を追加し、マイグレーションを実行

###  やってないこと
   - ゲーム本体の実装: マッチング成立後のゲームロジックやUIは未実装です。
   - リアルタイム通信: チャットや通知、ゲーム状態の同期など、WebSocket等を用いたリアルタイム通信機能は未実装です。
   - テスト: 一部のサーバーサイドのテストを除き、フロントエンドのテストは未実装です。

### 関連issue
close #57 
close #11 
