### PR TITLE
feat: ユーザー作成時のfeedback（成功/失敗）ref

### DIFF
--- a/client/features/auth/register.ts
+++ b/client/features/auth/register.ts
@@ -3,6 +3,7 @@ import {
 	type RegisterUserResponse,
 	registerUserFormSchema,
 } from "@shared/api/auth";
+import { AxiosError } from "axios";
 import { ApiClient } from "client/api/api_client";
 import {
 	Button,
@@ -60,8 +61,17 @@ export class Register extends Component {
 					}
 				} catch (error) {
 					console.error("Sign-up failed:", error);
+					if (error instanceof AxiosError) {
+						new FloatingBanner({
+							message:
+								error.response?.data?.error?.message ||
+								`登録に失敗しました (${error.response?.status} ${error.response?.statusText})`,
+							type: "error",
+						}).show();
+						return;
+					}
 					new FloatingBanner({
-						message: "登録に失敗しました。入力内容をご確認ください。",
+						message: `登録に失敗しました。入力内容をご確認ください。 ${error}`,
 						type: "error",
 					}).show();
 				}


### PR DESCRIPTION
### やったこと
- ユーザー登録の成功／失敗をしらせる floating window - skitheom
- 登録成功時に、ログイン画面への遷移 - skitheom
- 失敗の理由を具体的に通知する（メールアドレスの重複やユーザー名の重複等）- syagi

### やってないこと

### 動作確認
- [ ] example

ref #121 